### PR TITLE
sysv: Monter cgroup fs for minnetrykkinformasjon tidlig

### DIFF
--- a/bootscripts/ChangeLog
+++ b/bootscripts/ChangeLog
@@ -1,3 +1,6 @@
+2023-07-28 Xi Ruoyao <xry111@xry111.site>
+   * In mountvirtfs, mount /sys/fs/cgroup for udev from systemd-254.
+
 2023-07-22 Xi Ruoyao <xry111@xry111.site>
    * In mountvirtfs, create symlinks /dev/{fd,std{in,out,err}} and
      /dev/core (optional).

--- a/bootscripts/lfs/init.d/mountvirtfs
+++ b/bootscripts/lfs/init.d/mountvirtfs
@@ -63,6 +63,10 @@ case "${1}" in
       log_info_msg2 " ${INFO}/dev/shm"
       mount -o nosuid,nodev /dev/shm || failed=1
 
+       mkdir -p /sys/fs/cgroup
+      log_info_msg2 " ${INFO}/sys/fs/cgroup"
+      mount -o nosuid,noexec,nodev /sys/fs/cgroup || failed=1
+
       (exit ${failed})
       evaluate_retval
       if [ "${failed}" = 1 ]; then

--- a/chapter01/changelog.xml
+++ b/chapter01/changelog.xml
@@ -41,6 +41,19 @@
     -->
 
     <listitem revision='sysv'>
+      <para>28.07.2023</para>
+      <itemizedlist>
+        <listitem revision='sysv'>
+          <para>[xry111] - Aktiver cgroup-basert minnetrykkinformasjon
+          i kjernen, og legg til cgroup-filsystemet i /etc/fstab og
+          mountvirtfs bootscript. Dette er en forberedelse til udev fra
+          systemd-254.  Adresserer
+          <ulink url='&lfs-ticket-root;5293'>#5293</ulink>.</para>
+        </listitem>
+      </itemizedlist>
+    </listitem>
+
+    <listitem revision='sysv'>
       <para>22.07.2023</para>
       <itemizedlist>
         <listitem revision='sysv'>

--- a/chapter10/fstab.xml
+++ b/chapter10/fstab.xml
@@ -22,17 +22,18 @@
 <screen revision="sysv"><userinput>cat &gt; /etc/fstab &lt;&lt; "EOF"
 <literal># Begin /etc/fstab
 
-# file system  mount-point  type     options             dump  fsck
-#                                                              order
+# file system  mount-point    type     options             dump  fsck
+#                                                                order
 
-/dev/<replaceable>&lt;xxx&gt;</replaceable>     /            <replaceable>&lt;fff&gt;</replaceable>    defaults            1     1
-/dev/<replaceable>&lt;yyy&gt;</replaceable>     swap         swap     pri=1               0     0
-proc           /proc        proc     nosuid,noexec,nodev 0     0
-sysfs          /sys         sysfs    nosuid,noexec,nodev 0     0
-devpts         /dev/pts     devpts   gid=5,mode=620      0     0
-tmpfs          /run         tmpfs    defaults            0     0
-devtmpfs       /dev         devtmpfs mode=0755,nosuid    0     0
-tmpfs          /dev/shm     tmpfs    nosuid,nodev        0     0
+/dev/<replaceable>&lt;xxx&gt;</replaceable>     /              <replaceable>&lt;fff&gt;</replaceable>    defaults            1     1
+/dev/<replaceable>&lt;yyy&gt;</replaceable>     swap           swap     pri=1               0     0
+proc           /proc          proc     nosuid,noexec,nodev 0     0
+sysfs          /sys           sysfs    nosuid,noexec,nodev 0     0
+devpts         /dev/pts       devpts   gid=5,mode=620      0     0
+tmpfs          /run           tmpfs    defaults            0     0
+devtmpfs       /dev           devtmpfs mode=0755,nosuid    0     0
+tmpfs          /dev/shm       tmpfs    nosuid,nodev        0     0
+cgroup2        /sys/fs/cgroup cgroup2  nosuid,noexec,nodev 0     0
 
 # End /etc/fstab</literal>
 EOF</userinput></screen>

--- a/chapter10/kernel.xml
+++ b/chapter10/kernel.xml
@@ -135,7 +135,12 @@
    [*]   Randomize the address of the kernel image (KASLR) [CONFIG_RANDOMIZE_BASE]
 General setup ---&gt;
    [ ] Compile the kernel with warnings as errors [CONFIG_WERROR]
+   CPU/Task time and stats accounting ---&gt;
+      [*] Pressure stall information tracking [CONFIG_PSI]
+      [ ]   Require boot parameter to enable pressure stall information tracking [CONFIG_PSI_DEFAULT_DISABLED]
    &lt; &gt; Enable kernel headers through /sys/kernel/kheaders.tar.xz [CONFIG_IKHEADERS]
+   [*] Control Group support [CONFIG_CGROUPS]   ---&gt;
+      [*] Memory controller [CONFIG_MEMCG]
    [ ] Configure standard kernel features (expert users) [CONFIG_EXPERT]
 General architecture-dependent options  ---&gt;
    [*] Stack Protector buffer overflow detection [CONFIG_STACKPROTECTOR]

--- a/packages.ent
+++ b/packages.ent
@@ -383,12 +383,12 @@
 <!ENTITY less-fin-du "4.3 MB">
 <!ENTITY less-fin-sbu "mindre enn 0.1 SBU">
 
-<!ENTITY lfs-bootscripts-version "20230722">      <!-- Scripts depend on this format -->
-<!ENTITY lfs-bootscripts-size "33 KB">
+<!ENTITY lfs-bootscripts-version "20230728">      <!-- Scripts depend on this format -->
+<!ENTITY lfs-bootscripts-size "BOOTSCRIPTS-SIZE KB">
 <!ENTITY lfs-bootscripts-url "&downloads-root;lfs-bootscripts-&lfs-bootscripts-version;.tar.xz">
-<!ENTITY lfs-bootscripts-md5 "569217b0b56f98fd267d38d72ee20132">
+<!ENTITY lfs-bootscripts-md5 "BOOTSCRIPTS-MD5SUM">
 <!ENTITY lfs-bootscripts-home " ">
-<!ENTITY lfs-bootscripts-cfg-du "244 KB">
+<!ENTITY lfs-bootscripts-cfg-du "BOOTSCRIPTS-INSTALL-KB KB">
 <!ENTITY lfs-bootscripts-cfg-sbu "mindre enn 0.1 SBU">
 
 <!ENTITY libcap-version "2.69">


### PR DESCRIPTION
Forbered på systemd-254-oppdatering. Se #5293 for detaljer.