### PR TITLE
dependencies: Legg til patchutils som valgfri avhengighets sjekk

### DIFF
--- a/appendices/dependencies.xml
+++ b/appendices/dependencies.xml
@@ -437,6 +437,9 @@
         <seglistitem>
           <seg>
             <ulink url='&github;/testing-cabal/subunit'>libsubunit</ulink>
+			og
+            <ulink url='http://cyberelk.net/tim/software/patchutils/'>
+              patchutils</ulink>
           </seg>
         </seglistitem>
       </segmentedlist>


### PR DESCRIPTION
Konfigurasjonsskriptet sier:

configure: WARNING: filterdiff not installed; build will not be reproducible.

Filterdiff programmet er en del av patchutils.