### PR TITLE
Gjør /dev/shm mount og umount verbose

### DIFF
--- a/chapter07/kernfs.xml
+++ b/chapter07/kernfs.xml
@@ -109,7 +109,7 @@ mount -vt tmpfs tmpfs $LFS/run</userinput></screen>
 <screen><userinput>if [ -h $LFS/dev/shm ]; then
   mkdir -pv $LFS/$(readlink $LFS/dev/shm)
 else
-  mount -t tmpfs -o nosuid,nodev tmpfs $LFS/dev/shm
+  mount -vt tmpfs -o nosuid,nodev tmpfs $LFS/dev/shm
 fi</userinput></screen>
 
   </sect2>

--- a/chapter11/reboot.xml
+++ b/chapter11/reboot.xml
@@ -113,7 +113,7 @@
   <para>Deretter avmontere de virtuelle filsystemene:</para>
 
 <screen><userinput>umount -v $LFS/dev/pts
-mountpoint -q $LFS/dev/shm &amp;&amp; umount $LFS/dev/shm
+mountpoint -q $LFS/dev/shm &amp;&amp; umount -v $LFS/dev/shm
 umount -v $LFS/dev
 umount -v $LFS/run
 umount -v $LFS/proc


### PR DESCRIPTION
Nesten alle kommandoer i lfs er verbose. Vet ikke hvorfor disse ikke er det.