### PR TITLE
/etc/os-release: Legg til HOME_URL feltet

### DIFF
--- a/chapter11/theend.xml
+++ b/chapter11/theend.xml
@@ -58,6 +58,7 @@ VERSION="&version;"
 ID=lfs
 PRETTY_NAME="Linux From Scratch &version;"
 VERSION_CODENAME="&lt;your name here&gt;"
+HOME_URL="&lfs-root;lfs/"
 EOF</userinput></screen>
 
   <para>Pass på å tilpasse feltene 'DISTRIB_CODENAME' og


### PR DESCRIPTION
Den brukes av AppStream i BLFS for å beregne ID for operasjonen system.