### PR TITLE
glibc: Fiks CVE-2023-4911

### DIFF
--- a/chapter01/changelog.xml
+++ b/chapter01/changelog.xml
@@ -41,7 +41,17 @@
     -->
 
     <listitem>
-      <para>2023-10-01</para>
+      <para>03.10.2023</para>
+      <itemizedlist>
+        <listitem>
+          <para>[xry111] - Oppdater Glibc oppstrøms fikser oppdatering for å fikse
+          CVE-2023-4911.</para>
+        </listitem>
+      </itemizedlist>
+    </listitem>
+
+    <listitem>
+      <para>01.10.2023</para>
       <itemizedlist>
         <listitem>
            <para>[bdubbs] - Deaktiver byggingen av nscd i glibc. Fikser

--- a/patches.ent
+++ b/patches.ent
@@ -14,8 +14,8 @@
 <!ENTITY glibc-fhs-patch-md5 "9a5997c3452909b1769918c759eff8a2">
 <!ENTITY glibc-fhs-patch-size "2.8 KB">
 
-<!ENTITY glibc-upstream-fixes-patch "glibc-&glibc-version;-upstream_fixes-2.patch">
-<!ENTITY glibc-upstream-fixes-patch-md5 "a5a06adb7f61dcc901f35d810ac8a1c0">
+<!ENTITY glibc-upstream-fixes-patch "glibc-&glibc-version;-upstream_fixes-3.patch">
+<!ENTITY glibc-upstream-fixes-patch-md5 "545977e0b5c341ba945cf4b5de92f1e2">
 <!ENTITY glibc-upstream-fixes-patch-size "28 KB">
 
 <!ENTITY grub-upstream-fixes-patch "grub-&grub-version;-upstream_fixes-1.patch">


### PR DESCRIPTION
Render fint sysv, systemd, pdf og nochunks