### PR TITLE
bootscripts: endre "halt stop" til "halt start"

### DIFF
--- a/bootscripts/ChangeLog
+++ b/bootscripts/ChangeLog
@@ -1,3 +1,8 @@
+2023-10-04 Pierre Labastie <pierre.labastie@neuf.fr>
+   * After the changes done on 2022-03-24, several "halt stop" should
+     have been changed to "halt start". Done now. Fortunately, those
+     occur only when something wrong happens with disks or devices.
+
 2023-07-28 Xi Ruoyao <xry111@xry111.site>
    * In mountvirtfs, mount /sys/fs/cgroup for udev from systemd-254.
 

--- a/bootscripts/lfs/init.d/checkfs
+++ b/bootscripts/lfs/init.d/checkfs
@@ -63,7 +63,7 @@ case "${1}" in
 
          log_info_msg "Press Enter to continue..."
          wait_for_user
-         /etc/rc.d/init.d/halt stop
+         /etc/rc.d/init.d/halt start
       else
          log_success_msg2
       fi
@@ -127,7 +127,7 @@ case "${1}" in
 
          log_info_msg "Press Enter to continue..."
          wait_for_user
-         /etc/rc.d/init.d/halt stop
+         /etc/rc.d/init.d/halt start
       fi
 
       if [ "${error_value}" -ge 16 ]; then

--- a/bootscripts/lfs/init.d/udev
+++ b/bootscripts/lfs/init.d/udev
@@ -41,7 +41,7 @@ case "${1}" in
          log_info_msg "$msg"
          log_info_msg "Press Enter to continue..."
          wait_for_user
-         /etc/rc.d/init.d/halt stop
+         /etc/rc.d/init.d/halt start
       fi
 
       # Start the udev daemon to continually watch for, and act on,


### PR DESCRIPTION
Commit 27d23b1d har endret konvensjonen som skripter med Sxxx symbolkoblinger skal kjøres med "stopp"-parameter i kjørenivå 0 og 6. De skal nå kalles opp med den mer intuitive "start"-parameteren. Men noen få skript kaller fortsatt "/etc/init.d/halt stop". Heldigvis dette forekommer i kodestier som sjelden kjøres (uopprettelige feil). Så det ble ikke lagt merke til før nå. Uansett, dette er fikset i denne commit.