### PR TITLE
pdf-bok: fiks sidenummerering i del III

### DIFF
--- a/stylesheets/lfs-xsl/pdf/lfs-pagesetup.xsl
+++ b/stylesheets/lfs-xsl/pdf/lfs-pagesetup.xsl
@@ -241,4 +241,22 @@
     </fo:block>
   </xsl:template>
 
+  <!-- page.number.format
+       We want roman numerals only in book's preface, not parts prefaces
+       (if any). The original template is in {docbook-xsl}/fo/pagesetup.xsl -->
+  <xsl:template name="page.number.format">
+    <xsl:param name="element" select="local-name(.)"/>
+    <xsl:param name="master-reference" select="''"/>
+
+    <xsl:choose>
+      <xsl:when test="$element = 'toc' and self::book">i</xsl:when>
+      <xsl:when test="$element = 'set'">i</xsl:when>
+      <xsl:when test="$element = 'book'">i</xsl:when>
+      <xsl:when test="$element = 'preface' and not(ancestor::part)">i</xsl:when>
+      <xsl:when test="$element = 'dedication'">i</xsl:when>
+      <xsl:when test="$element = 'acknowledgements'">i</xsl:when>
+      <xsl:otherwise>1</xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
 </xsl:stylesheet>


### PR DESCRIPTION
Som standard er sidenummerering i <forord> i romertall. Dette er ok for bokforordet, men ikke for del III forord. Så kopier side.number.format-malen fra docbook-stilark til stylesheets/lfs-xsl/pdf/lfs-pagesetup.xsl, og endre den.

Rapportert av: Vladimir Pertsev på lfs-dev-listen