### PR TITLE
udev: Fjern fire udev regler som tilhører logind

### DIFF
--- a/chapter08/udev.xml
+++ b/chapter08/udev.xml
@@ -117,9 +117,12 @@ meson setup \
       $(realpath libudev.so --relative-to .)</userinput></screen>
 
     <para>Fjern en udevregelfil som krever en full Systemd
-    installasjon:</para>
+    installasjon og fire udev regelfiler for påloggingsbehandlingen (hvis du trenger
+    en login manager, installer BLFS elogind pakken etter å ha fullført LFS;
+    elogind pakken vil også installere disse udev-reglene):</para>
 
-<screen><userinput remap="make">rm rules.d/90-vconsole.rules</userinput></screen>
+<screen><userinput remap="make">rm rules.d/{70-uaccess,71-seat,73-seat-late,90-vconsole}.rules
+rm ../rules.d/70-power-switch.rules</userinput></screen>
 
     <para>Installer pakken:</para>
 


### PR DESCRIPTION
De er egentlig ikke nyttige uten pålogging. BLFS elogind pakken vil gi dem også, så vi bør fjerne dem og unngå en pakkebehandling konflikt.