### PR TITLE
kernfs: Revider kommandoen som oppretter lenkemålet i tilfelle /dev/s…

### DIFF
--- a/chapter07/kernfs.xml
+++ b/chapter07/kernfs.xml
@@ -107,7 +107,7 @@ mount -vt tmpfs tmpfs $LFS/run</userinput></screen>
       monterer vi eksplisitt en tmpfs:</para>
 
 <screen><userinput>if [ -h $LFS/dev/shm ]; then
-  mkdir -pv $LFS/$(readlink $LFS/dev/shm)
+  (cd $LFS/dev; mkdir $(readlink shm))
 else
   mount -vt tmpfs -o nosuid,nodev tmpfs $LFS/dev/shm
 fi</userinput></screen>


### PR DESCRIPTION
…hm er en symbolkobling

Når /dev/shm er en symbolkobling, må vi lage målet ellers vil noen tester mislykkes og Python 3 vil bli feilkonfigurert. Vi skrev det som:

mkdir -pv $LFS/$(readlink $LFS/dev/shm)

Men hvis $LFS/dev/shm er en relativ symbolkobling (si ../run/shm), ender vi opp:

mkdir -pv /mnt/lfs/../run/shm

Denne kommandoen vil opprette /mnt/run/shm, ikke $LFS/mnt/shm som vi forventet. Vri den litt for å få den til å fungere for både absolutte symbolkoblinger og relative symbolkoblinger.