### PR TITLE
Generer utf-8 kodet html

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,6 @@ book: validate profile-html
          true;                                        \
          /bin/bash obfuscate.sh $$filename;           \
          sed -e "s@text/html@application/xhtml+xml@g" \
-             -e "s/\xa9/\&copy;/ "                    \
              -i $$filename;                           \
    done;
 

--- a/stylesheets/lfs-xsl/chunk-slave.xsl
+++ b/stylesheets/lfs-xsl/chunk-slave.xsl
@@ -10,9 +10,6 @@
   <!-- Upstream XHTML presentation templates -->
   <xsl:import href="http://docbook.sourceforge.net/release/xsl/current/xhtml/docbook.xsl"/>
 
-  <!-- Use ISO-8859-1 for output instead of default UTF-8 -->
-  <xsl:param name="chunker.output.encoding" select="'ISO-8859-1'"/>
-
   <!-- Including our customized elements templates -->
   <xsl:include href="common.xsl"/>
   <xsl:include href="xhtml/lfs-admon.xsl"/>

--- a/tidy.conf
+++ b/tidy.conf
@@ -1,8 +1,6 @@
 indent-spaces: 2
 wrap: 78
 tab-size: 8
-input-encoding: latin1
-output-encoding: latin1
 write-back: yes
 markup: yes
 indent: yes


### PR DESCRIPTION
Dette fjerner flere problemer med feil kodinger... Sed for &copy; er ikke nødvendig lenger
tidy.conf må endres for å fjerne spesifikasjonen for latin1 som inngangs- og utgangskodinger.