### PR TITLE
whatsnew: Bruk <tittel> på siden for pakker som pakkenavn

### DIFF
--- a/chapter01/whatsnew.xml
+++ b/chapter01/whatsnew.xml
@@ -153,7 +153,7 @@
       <para>Libcap-&libcap-version;</para>
     </listitem>-->
     <listitem>
-      <para>Libelf-&elfutils-version; (from elfutils)</para>
+      <para>Libelf fra Elfutils-&elfutils-version;</para>
     </listitem>
     <!--<listitem>
       <para>Libffi-&libffi-version;</para>
@@ -252,7 +252,7 @@
       <para>Tzdata-&tzdata-version;</para>
     </listitem>-->
 	<!--<listitem revision="sysv">
-       <para>Udev-&systemd-version; (fra systemd)</para>
+       <para>Udev fra Systemd-&systemd-version;</para>
     </listitem>-->
     <listitem>
       <para>Util-linux-&util-linux-version;</para>


### PR DESCRIPTION
Dette er mer konsekvent, og det reduserer antallet forskjellige oversettbare strenger for oversettere. De fleste pakkenavnene i whatsnew har allerede blitt justert med <title>s, lag nå disse to "fra ..." pakker så.