### PR TITLE
Fjern bortkommen referanser til TESTSUITEFLAGS

### DIFF
--- a/chapter08/autoconf.xml
+++ b/chapter08/autoconf.xml
@@ -61,17 +61,6 @@
     For å kjøre testene uansett, utsted:</para>
  -->
 <screen><userinput remap="test">make check</userinput></screen>
-<!--
-    <para>Dette tar lang tid, ca &autoconf-fin-sbu-tests; SBU. I tillegg,
-    flere tester hoppes over som bruker Automake. For full testdekning,
-    Autoconf kan testes på nytt etter at Automake er installert. I tillegg,
-    to tester mislykkes på grunn av endringer i libtool-2.4.3 og senere.</para>
--->
-    <note><para>Testtiden for autoconf kan reduseres betydelig på en
-    system med flere kjerner. For å gjøre dette, legg til
-    <command>TESTSUITEFLAGS=-j&lt;N&gt;</command> til linjen over. For
-    eksempel ved å bruke -j4 kan testtiden reduseres med over 60
-    prosent.</para></note>
 
     <para>Installer pakken:</para>
 

--- a/chapter08/libtool.xml
+++ b/chapter08/libtool.xml
@@ -54,12 +54,6 @@
 
 <screen><userinput remap="test">make -k check</userinput></screen>
 
-    <note><para>Testtiden for libtool kan reduseres betydelig på et
-    system med flere kjerner. For å gjøre dette, legg til
-    <command>TESTSUITEFLAGS=-j&lt;N&gt;</command> til linjen over. For
-    eksempel kan bruk av -j4 redusere testtiden med over 60
-    prosent.</para></note>
-
     <para>Fem tester er kjent for å mislykkes i LFS byggemiljøet pga
     en sirkulær avhengighet, men disse testene består hvis de sjekkes på nytt etter
     at automake er installert.  I tillegg, med grep-3.8, vil to tester

--- a/chapter08/tar.xml
+++ b/chapter08/tar.xml
@@ -72,13 +72,6 @@
 
 <screen><userinput remap="test">make check</userinput></screen>
 
-    <!-- On one system the -j4 improvement is 167s - 46s = 121s (72.46%) -->
-    <note><para>Testtiden for TAR kan reduseres betydelig på et
-    system med flere kjerner. For å gjøre dette, legg til
-    <command>TESTSUITEFLAGS=-j&lt;N&gt;</command> til linjen over.
-    For eksempel kan bruk av -j4 redusere testtiden med over 70
-    prosent.</para></note>
-
     <para>En test, capabilities: binary store/restore, er kjent for å mislykkes hvis den
     kjøres (på grunn av at LFS mangler selinux), men vil bli hoppet over hvis vertskjernen ikke
     støtter utvidede attributter eller sikkerhetsetiketter på filsystemet


### PR DESCRIPTION
Nå er TESTSUITEFLAGS satt globalt i kapittel 7.4, så det er ikke nødvendig å nevne det igjen og igjen i individuelle pakker.