### PR TITLE
Fiks definisjonen av C.UTF-8 lokaliteten

### DIFF
--- a/chapter01/changelog.xml
+++ b/chapter01/changelog.xml
@@ -41,6 +41,16 @@
     -->
     
     <listitem>
+      <para>09.01.2024</para>
+      <itemizedlist>
+        <listitem>
+          <para>[renodr] - Fiks definisjonen av C.UTF-8 lokaliteten. Fikser
+          <ulink url="&lfs-ticket-root;5409">#5409</ulink>.</para>
+        </listitem>
+      </itemizedlist>
+    </listitem>
+
+    <listitem>
       <para>31.12.2023</para>
       <itemizedlist>
         <listitem>

--- a/chapter08/glibc.xml
+++ b/chapter08/glibc.xml
@@ -297,7 +297,7 @@ localedef -i zh_TW -f UTF-8 zh_TW.UTF-8</userinput></screen>
     når du trenger dem. For eksempel er følgende to lokaliteter
     nødvendig for noen tester senere i dette kapittelet:</para>
 
-<screen role="nodump"><userinput remap="locale-full">localedef -i POSIX -f UTF-8 C.UTF-8 2> /dev/null || true
+<screen role="nodump"><userinput remap="locale-full">localedef -i C -f UTF-8 C.UTF-8
 localedef -i ja_JP -f SHIFT_JIS ja_JP.SJIS 2> /dev/null || true</userinput></screen>
 
     <note><para>Glibc bruker nå libidn2 når den løser internasjonalisert


### PR DESCRIPTION
Dette fikser en testfeil i Epiphany.