### PR TITLE
treomfattende: Bruk <ulink> i stedet for <filename> for mansider

### DIFF
--- a/chapter02/creatingpartition.xml
+++ b/chapter02/creatingpartition.xml
@@ -40,7 +40,8 @@
   <filename class="devicefile">/dev/sda</filename> for den primære
   diskstasjonen. Lag en innebygd Linux partisjon og en
   <systemitem class="filesystem">swap</systemitem> partisjon, hvis nødvendig. Vennligst
-  referere til <filename>cfdisk(8)</filename> eller <filename>fdisk(8)</filename> hvis
+  referere til <ulink role='man' url='&man;cfdisk.8'>cfdisk(8)</ulink> eller
+  <ulink role='man' url='&man;fdisk.8'>fdisk(8)</ulink> hvis
   du ennå ikke vet hvordan du bruker programmene.</para>
 
   <note><para>For erfarne brukere er andre partisjoneringsordninger mulig.

--- a/chapter04/addinguser.xml
+++ b/chapter04/addinguser.xml
@@ -99,6 +99,7 @@ esac</userinput></screen>
   <para><quote><parameter>-</parameter></quote> instruerer
   <command>su</command> å starte et påloggingsskall i motsetning til et ikke-påloggingsskall.
   Forskjellen mellom disse to skjelltypene finner du i detalj i
-  <filename>bash(1)</filename> og <command>info bash</command>.</para>
+  <ulink role='man' url='&man;bash.1'>bash(1)</ulink> og <command>info
+  bash</command>.</para>
 
 </sect1>

--- a/chapter04/settingenviron.xml
+++ b/chapter04/settingenviron.xml
@@ -79,8 +79,8 @@ EOF</userinput></screen>
   <para>Å sette brukerfilopprettingsmasken (umask) til 022 sikrer at nye
   opprettede filer og mapper bare kan skrives av eieren, men er
   lesbar og kjørbar av alle (forutsatt at standardmoduser brukes av
-  <filename>open(2)</filename> systemkall, vil nye filer ende opp med
-  tillatelsesmodus 644 og mapper med modus 755).</para>
+  <ulink role='man' url='&man;open.2'>open(2)</ulink> systemkall, nye filer
+  vil ende opp med tillatelsesmodus 644 og mapper med modus 755).</para>
       </listitem>
     </varlistentry>
 

--- a/chapter05/glibc.xml
+++ b/chapter05/glibc.xml
@@ -59,8 +59,9 @@ esac</userinput></screen>
       <para>
         Kommandoen ovenfor er riktig. <command>ln</command> kommandoen har
         flere syntaktiske versjoner, så sørg for å sjekke
-        <command>info coreutils ln</command> og <filename>ln(1)</filename>
-        før du rapporterer det som kan se ut til å være en feil.
+        <command>info coreutils ln</command> og <ulink role='man'
+        url='&man;ln.1'>ln(1)</ulink> før du rapporterer hva som kan se ut til å være
+        en feil.
       </para>
     </note>
 

--- a/chapter08/e2fsprogs.xml
+++ b/chapter08/e2fsprogs.xml
@@ -159,7 +159,8 @@ install-info --dir-file=/usr/share/info/dir /usr/share/info/com_err.info</userin
     <screen role='nodump'><userinput>sed 's/metadata_csum_seed,//' -i /etc/mke2fs.conf</userinput></screen>
 
     <para>
-      Les mansiden <filename>mke2fs.conf(5)</filename> for detaljer.
+      Les mansiden <ulink role='man'
+      url='&man;mke2fs.conf.5'>mke2fs.conf(5)</ulink> for detaljer.
     </para>
   </sect2>
 

--- a/chapter08/openssl.xml
+++ b/chapter08/openssl.xml
@@ -163,7 +163,7 @@ make MANSUFFIX=ssl install</userinput></screen>
             er et kommandolinjeverktøy for bruk av de ulike kryptografifunksjonene
             til <application>OpenSSL</application> sitt kryptobibliotek fra
             skallet. Den kan brukes til ulike funksjoner som er dokumentert i
-            <filename>openssl(1)</filename>
+            <ulink role='man' url='&man;openssl.1'>openssl(1)</ulink>
           </para>
           <indexterm zone="ch-system-openssl openssl-prog">
             <primary sortas="b-openssl">openssl</primary>
@@ -194,8 +194,9 @@ make MANSUFFIX=ssl install</userinput></screen>
         <listitem>
           <para>
             implementerer protokollen Transport Layer Security (TLS v1).
-            Det gir en rik API, dokumentasjon
-            kan bli funnet i <filename>ssl(7)</filename>
+            Det gir en rik API, dokumentasjonen
+            kan bli funnet i <ulink role='man'
+            url='&man;ssl.7'>ssl(7)</ulink>
           </para>
           <indexterm zone="ch-system-openssl libssl">
             <primary sortas="c-libssl">libssl.so</primary>

--- a/chapter08/shadow.xml
+++ b/chapter08/shadow.xml
@@ -203,8 +203,8 @@ make -C man install-man</userinput></screen>
     å sende enten <parameter>-g</parameter> eller <parameter>-N</parameter>
     parameter til <command>useradd</command>, eller endre innstillingen for
     <parameter>USERGROUPS_ENAB</parameter> i
-    <filename>/etc/login.defs</filename>. Se <filename>useradd(8)</filename>
-    for mer informasjon.</para>
+    <filename>/etc/login.defs</filename>. Se <ulink role='man'
+    url='&man;useradd.8'>useradd(8)</ulink> for mer informasjon.</para>
 
     <para>For det andre, for å endre standardparametrene, filen
     <filename>/etc/default/useradd</filename> må lages og skreddersys

--- a/chapter08/util-linux.xml
+++ b/chapter08/util-linux.xml
@@ -584,7 +584,8 @@ su tester -c "make -k check"</userinput></screen>
         <term><command>irqtop</command></term>
         <listitem>
           <para>Viser informasjon om kjerneavbruddsteller i
-          <filename>top(1)</filename> stilvisning</para>
+          <ulink role='man' url='&man;top.1'>top(1)</ulink> 
+          stilvisning</para>
           <indexterm zone="ch-system-util-linux irqtop">
             <primary sortas="b-irqtop">irqtop</primary>
           </indexterm>

--- a/chapter09/networkd.xml
+++ b/chapter09/networkd.xml
@@ -50,9 +50,11 @@
     <filename class="extension">.netdev</filename> og
     <filename class="extension">.network</filename> filene. For detaljert
     beskrivelser og eksempelinnhold i disse konfigurasjonsfilene, se
-    <filename>systemd-link(5)</filename>,
-    <filename>systemd-netdev(5)</filename> og
-    <filename>systemd-network(5)</filename> manualsider.</para>
+    <ulink role='man' url='&man;systemd-link.5'>systemd-link(5)</ulink>,
+    <ulink role='man' url='&man;systemd-netdev.5'>systemd-netdev(5)</ulink>,
+    og <ulink role='man'
+    url='&man;systemd-network.5'>systemd-network(5)</ulink> 
+    manualsider.</para>
 
     <sect3 id="systemd-network-devices">
       <title>Navngivning av nettverksenheter</title>
@@ -113,7 +115,7 @@ Name=ether0</literal>
 EOF</userinput></screen>
 
           <para>
-             Se <filename>systemd.link(5)</filename> for mer informasjon.
+             Se <ulink role='man' url='&man;systemd.link.5'>systemd.link(5)</ulink> for mer informasjon.
           </para>
         </listitem>
 
@@ -357,7 +359,9 @@ EOF</userinput></screen>
      <literal>localhost.localdomain</literal>, eller vertsnavnet (uten
      domene) fordi de håndteres av
      <systemitem class='library'>myhostname</systemitem> NSS modul, les
-     mansiden <filename>nss-myhostname(8)</filename> for detaljer.</para>
+     mansiden <ulink role='man'
+     url='&man;nss-myhostname.8'>nss-myhostname(8)</ulink> for
+     detaljer.</para>
 
      <para>::1 oppføringen er IPv6 motstykket til 127.0.0.1 og representerer
      IPv6 loopback grensesnittet.</para>

--- a/chapter09/systemd-custom.xml
+++ b/chapter09/systemd-custom.xml
@@ -21,8 +21,9 @@
     av alternativer for å kontrollere grunnleggende systemoperasjoner. Standardfilen har alle
     oppføringer kommentert med standardinnstillingene angitt. Denne filen er
     hvor loggnivået kan endres, samt noen grunnleggende logginnstillinger.
-    Se <filename>systemd-system.conf(5)</filename> manualside for detaljer
-    om hvert konfigurasjonsalternativ.</para>
+    See the <ulink role='man'
+    url='&man;systemd-system.conf.5'>systemd-system.conf(5)</ulink> manualside
+    for detaljer om hvert konfigurasjonsalternativ.</para>
 
   </sect2>
 
@@ -89,8 +90,8 @@ EOF</userinput></screen>
     <filename class="directory">/etc/tmpfiles.d</filename> overstyrer
     filer med samme navn i
     <filename class="directory">/usr/lib/tmpfiles.d</filename>. Se
-    <filename>tmpfiles.d(5)</filename> manualside for filformat
-    detaljer.</para>
+    <ulink role='man' url='&man;tmpfiles.d.5'>tmpfiles.d(5)</ulink> manualside
+    for filformat detaljer.</para>
 
     <para>
       Merk at syntaksen for
@@ -135,7 +136,8 @@ Restart=always
 RestartSec=30</literal>
 EOF</userinput></screen>
 
-     <para>Se <filename>systemd.unit(5)</filename> manualside for mer
+     <para>Se <ulink role='man'
+     url='&man;systemd.unit.5'>systemd.unit(5)</ulink> manualside for mer
      informasjon. Etter å ha opprettet konfigurasjonsfilen, kjør
      <userinput>systemctl daemon-reload</userinput> og <userinput>systemctl
      restart foobar</userinput> for å aktivere endringene i en tjeneste.</para>
@@ -251,10 +253,11 @@ cat &gt; /etc/systemd/coredump.conf.d/maxuse.conf &lt;&lt; EOF
 MaxUse=5G</literal>
 EOF</userinput></screen>
 
-    <para>Se <filename>systemd-coredump(8)</filename>,
-    <filename>coredumpctl(1)</filename>, og
-    <filename>coredump.conf.d(5)</filename> manualsidene for mer
-    informasjon.</para>
+    <para>Se <ulink role='man' url='&man;systemd-coredump.8'>systemd-coredump(8)</ulink>,
+    <ulink role='man' url='&man;coredumpctl.1'>coredumpctl(1)</ulink>, og
+    <ulink role='man'
+    url='&man;coredump.conf.d.5'>coredump.conf.d(5)</ulink> manualsidene for
+    mer informasjon.</para>
   </sect2>
 
   <sect2>

--- a/chapter09/udev.xml
+++ b/chapter09/udev.xml
@@ -225,8 +225,9 @@
       <para>Merk at <quote>softdep</quote> kommandoen tillater også
       <literal>pre:</literal> avhengigheter, eller en blanding av begge
       <literal>(Før) pre:</literal> og <literal>(Etter) post:</literal> avhengigheter.  Se
-      <filename>modprobe.d(5)</filename> manualside for mer informasjon
-      om <quote>softdep</quote> syntaks og muligheter.</para>
+      <ulink role='man' url='&man;modprobe.d.5'>modprobe.d(5)</ulink>
+      manualside for mer informasjon om <quote>softdep</quote> syntaks og
+      muligheter.</para>
 
       <para revision="sysv">Hvis den aktuelle modulen ikke er en innpakning og er
       nyttig i seg selv, konfigurer <command>modules</command> oppstartsskriptet til

--- a/chapter09/usage.xml
+++ b/chapter09/usage.xml
@@ -32,8 +32,9 @@
     <para>SysVinit (som vil bli referert til som <quote>init</quote> fra nå av)
     fungerer ved å bruke en kjørenivåordning. Det er syv (nummerert 0 til 6) kjørenivåer
     (faktisk er det flere kjørenivåer, men de er for spesielle tilfeller og er
-    vanligvis ikke brukt. Se <filename>init(8)</filename> for flere detaljer), og
-    hver av disse tilsvarer handlingene datamaskinen skal utføre
+    vanligvis ikke brukt. Se <ulink role='man'
+    url='&man;init.8'>init(8)</ulink> for flere detaljer).
+    Hver av disse tilsvarer handlingene datamaskinen skal utføre
     når den starter opp. Standard kjørenivå er 3. Her er
     beskrivelser av de ulike kjørenivåene etter hvert som de implementeres i LFS:</para>
 
@@ -341,9 +342,10 @@ EOF</userinput></screen>
   url="https://tldp.org/HOWTO/HOWTO-INDEX/other-lang.html"/>. Hvis du fortsatt er i
   tvil, se i <filename class="directory">/usr/share/keymaps</filename>
   og <filename class="directory">/usr/share/consolefonts</filename> mappene
-  for gyldige tastaturer og skjermfonter. Les <filename>loadkeys(1)</filename> og
-  <filename>setfont(8)</filename> manualsider for å finne de riktige
-  argumenter for disse programmene.</para>
+  for gyldige tastaturer og skjermfonter. Les <ulink role='man'
+  url='&man;loadkeys.1'>loadkeys(1)</ulink> and <ulink role='man'
+  url='&man;setfont.8'>setfont(8)</ulink> manualsider for å finne de
+  riktige argumenter for disse programmene.</para>
 
   <para><filename>/etc/sysconfig/console</filename> filen skal inneholde linjer
   av formen: VARIABLE="verdi". Følgende variabler gjenkjennes:</para>

--- a/chapter10/fstab.xml
+++ b/chapter10/fstab.xml
@@ -56,7 +56,7 @@ EOF</userinput></screen>
   class="partition">sda2</filename>, <filename
   class="partition">sda5</filename>, og <systemitem
   class="filesystem">ext4</systemitem>. For detaljer om de seks
-  feltene i denne filen, se <filename>fstab(5)</filename>.</para>
+  feltene i denne filen, se <ulink role='man' url='&man;fstab.5'>fstab(5)</ulink>.</para>
 
   <para>Filsystemer med MS-DOS eller Windows opprinnelse (dvs. vfat, ntfs, smbfs,
   cifs, iso9660, udf) trenger et spesielt alternativ, utf8, for ikke-ASCII

--- a/chapter10/kernel.xml
+++ b/chapter10/kernel.xml
@@ -324,7 +324,8 @@
     lokalisert i <xref linkend="ch-config-udev"/> og kjerne
     dokumentasjon i <filename
     class="directory">linux-&linux-version;/Documentation</filename> mappen.
-    Også, <filename>modprobe.d(5)</filename> kan være av interesse.</para>
+    Også, <ulink role='man' url='&man;modprobe.d.5'>modprobe.d(5)</ulink>
+    kan være av interesse.</para>
 
     <para>Med mindre modulstætte er deaktivert i kjernekonfigurasjonen,
     installere modulene med:</para>

--- a/general.ent
+++ b/general.ent
@@ -125,6 +125,7 @@
 <!ENTITY github          "https://github.com">
 <!ENTITY pypi-home       "https://pypi.org/project">
 <!ENTITY pypi-src        "https://pypi.org/packages/source">
+<!ENTITY man             "https://man.archlinux.org/man/">
 
 <!ENTITY root            "<systemitem class='username'>root</systemitem>">
 <!ENTITY lfs-user        "<systemitem class='username'>lfs</systemitem>">

--- a/prologue/typography.xml
+++ b/prologue/typography.xml
@@ -74,22 +74,27 @@ EOF</userinput></screen>
 
   <para>Dette formatet brukes til å kapsle inn tekst som er valgfri.</para>
 
-  <para><filename>passwd(5)</filename></para>
+  <para><ulink role='man' url='&man;passwd.5'>passwd(5)</ulink></para>
 
-  <para>Dette formatet brukes til å referere til en spesifikk manualside (manside). Tallet innenfor parentes
-  indikerer en bestemt del i manualene. For eksempel,
+  <para>Dette formatet brukes til å referere til en spesifikk manual (manside). Tallet innenfor parentes
+  indikerer en bestemt del i håndbøkene. For eksempel,
   <command>passwd</command> har to mansider. I henhold til LFS installasjonsinstruksjoner,
-  vil disse to mansidene være plassert på
+  disse to mansidene vil være plassert på
   <filename>/usr/share/man/man1/passwd.1</filename> og
-  <filename>/usr/share/man/man5/passwd.5</filename>. Når boken bruker <filename>passwd(5)</filename> refererer
+  <filename>/usr/share/man/man5/passwd.5</filename>. Når boken bruker
+  <ulink role='man' url='&man;/passwd.5'>passwd(5)</ulink> refererer
   den spesifikt til <filename>/usr/share/man/man5/passwd.5</filename>.
   <command>man passwd</command> vil skrive ut den første mansiden den finner som
   stemmer med <quote>passwd</quote>, som vil bli
-  <filename>/usr/share/man/man1/passwd.1</filename>. For dette eksemplet må du
-  kjøre <command>man 5 passwd</command> for å lese siden som
-  blir spesifisert. Merk at de fleste mansider ikke har duplikate
-  sidenavn i forskjellige seksjoner. Derfor er, <command>man <replaceable>&lt;programnavn&gt;
-  </replaceable></command> generelt tilstrekkelig.</para>
+  <filename>/usr/share/man/man1/passwd.1</filename>. For dette eksemplet
+  trenger du å kjøre <command>man 5 passwd</command> for å lese siden
+  som blir spesifisert. Merk at de fleste mansider ikke har duplikate
+  sidenavn i forskjellige seksjoner. Derfor, <command>man <replaceable>
+  &lt;programnavn&gt;</replaceable></command> er generelt tilstrekkelig. I LFS
+  boken er disse referansene til mansider også hyperkoblinger, så klikk på
+  en slik referanse vil åpne mansiden gjengitt i HTML fra
+  <ulink url='https://man.archlinux.org/'>Arch Linux manual
+  pages</ulink>.</para>
 
 </sect1>
 


### PR DESCRIPTION
Bruk <ulink> og lenke til den elektroniske mansiden på https://man.archlinux.org/ slik at brukeren kan henvise til mansidene mer enkelt.

Endringen gjøres via en sed kommando og lange linjer pakkes inn manuelt.