### PR TITLE
Rett opp og foren kommandoene som oppretter lenkemålet til /dev/shm

### DIFF
--- a/chapter07/kernfs.xml
+++ b/chapter07/kernfs.xml
@@ -97,7 +97,8 @@ mount -vt tmpfs tmpfs $LFS/run</userinput></screen>
     </variablelist>
 -->
       <para>I noen vertssystemer, <filename>/dev/shm</filename> er en
-      symbolsk lenke til <filename class="directory">/run/shm</filename>.
+      symbolsk lenke til en mappe, vanligvis
+      <filename class="directory">/run/shm</filename>.
       /run tmpfs ble montert ovenfor, så i dette tilfellet er det bare en
       mappe som må opprettes.</para>
 
@@ -107,7 +108,7 @@ mount -vt tmpfs tmpfs $LFS/run</userinput></screen>
       monterer vi eksplisitt en tmpfs:</para>
 
 <screen><userinput>if [ -h $LFS/dev/shm ]; then
-  (cd $LFS/dev; mkdir $(readlink shm))
+  mkdir -pv $LFS$(realpath /dev/shm)
 else
   mount -vt tmpfs -o nosuid,nodev tmpfs $LFS/dev/shm
 fi</userinput></screen>

--- a/chapter11/afterlfs.xml
+++ b/chapter11/afterlfs.xml
@@ -130,7 +130,7 @@ mounttype proc    proc   proc
 mounttype sys     sysfs  sysfs
 mounttype run     tmpfs  run
 if [ -h $LFS/dev/shm ]; then
-  mkdir -pv $LFS/$(readlink $LFS/dev/shm)
+  mkdir -pv $LFS$(realpath /dev/shm)
 else
   mounttype dev/shm tmpfs tmpfs -o nosuid,nodev
 fi 


### PR DESCRIPTION
$(realpath /dev/shm) vil returnere den absolutte banen til målet til /dev/shm, dermed vil kommandoen fungere for både absolutt symbolkobling og relativ symbolkobling.