### PR TITLE
Hvis vi trenger å lage lenkemålet til /dev/shm, gjør modusen 1777

### DIFF
--- a/chapter07/kernfs.xml
+++ b/chapter07/kernfs.xml
@@ -100,7 +100,7 @@ mount -vt tmpfs tmpfs $LFS/run</userinput></screen>
       symbolsk lenke til en mappe, vanligvis
       <filename class="directory">/run/shm</filename>.
       /run tmpfs ble montert ovenfor, så i dette tilfellet er det bare en
-      mappe som må opprettes.</para>
+      mappe som må opprettesmed riktig modus.</para>
 
       <para>I andre vertssystemer <filename>/dev/shm</filename> er et monteringspunkt
       for en tmpfs. I så fall vil monteringen av /dev ovenfor bare opprette
@@ -108,7 +108,7 @@ mount -vt tmpfs tmpfs $LFS/run</userinput></screen>
       monterer vi eksplisitt en tmpfs:</para>
 
 <screen><userinput>if [ -h $LFS/dev/shm ]; then
-  mkdir -pv $LFS$(realpath /dev/shm)
+  install -v -d -m 1777 $LFS$(realpath /dev/shm)
 else
   mount -vt tmpfs -o nosuid,nodev tmpfs $LFS/dev/shm
 fi</userinput></screen>

--- a/chapter11/afterlfs.xml
+++ b/chapter11/afterlfs.xml
@@ -130,7 +130,7 @@ mounttype proc    proc   proc
 mounttype sys     sysfs  sysfs
 mounttype run     tmpfs  run
 if [ -h $LFS/dev/shm ]; then
-  mkdir -pv $LFS$(realpath /dev/shm)
+  install -v -d -m 1777 $LFS$(realpath /dev/shm)
 else
   mounttype dev/shm tmpfs tmpfs -o nosuid,nodev
 fi 


### PR DESCRIPTION
For å matche oppførselen til en tmpfs montering. Ellers vil ikke-root bruker (for f.eks. testerbrukeren) få feil ved bruk av Glibc shm funksjoner.