### PR TITLE
dependencies: Kbd kan bruke Linux-PAM

### DIFF
--- a/appendices/dependencies.xml
+++ b/appendices/dependencies.xml
@@ -1566,7 +1566,9 @@
       <segmentedlist id="kbd-optdeps">
         <segtitle>&external;</segtitle>
         <seglistitem>
-          <seg>Ingen</seg>
+          <seg>
+            <ulink url="&blfs-book;postlfs/linux-pam.html">Linux-PAM</ulink>
+          </seg>
         </seglistitem>
       </segmentedlist>
 


### PR DESCRIPTION
Boken nevner allerede at vlock-programmet trenger PAM for å bygges, men på avhengighetssiden sier vi at Kbd ikke har noen eksterne valgfrie avhengigheter. Dette er åpenbart feil...