### PR TITLE
dependencies: Gettext kan bruke system libunistring

### DIFF
--- a/appendices/dependencies.xml
+++ b/appendices/dependencies.xml
@@ -1047,7 +1047,15 @@
       <segmentedlist id="gettext-optdeps">
         <segtitle>&external;</segtitle>
         <seglistitem>
-          <seg><ulink url='&blfs-book;general/libxml2.html'>libxml2</ulink></seg>
+          <seg>
+            <ulink url='&blfs-book;general/libunistring.html'>
+              libunistring
+            </ulink>
+            and
+            <ulink url='&blfs-book;general/libxml2.html'>
+              libxml2
+            </ulink>
+          </seg>
         </seglistitem>
       </segmentedlist>
 


### PR DESCRIPTION
Når system libunistring ikke er installert (for f.eks. bygning av LFS), en sendt kopi av libunistring brukes.