### PR TITLE
generalinstructions: Fjern en falsk uttalelse om "cp -R ødelegger sym…

### DIFF
--- a/part3intro/generalinstructions.xml
+++ b/part3intro/generalinstructions.xml
@@ -114,7 +114,7 @@
             <para>Ikke bruk noen metode bortsett fra <command>tar</command> kommandoen
               for å trekke ut kildekoden. Spesielt ved å bruke <command>cp -R</command>
               kommandoen for å kopiere
-              kildekodetre et annet sted kan ødelegge lenker og
+              kildekodetre et annet sted kan ødelegge
               tidsstempler i kildetreet, og føre til at byggingen mislykkes.</para>
             </listitem>
             <listitem>


### PR DESCRIPTION
…bolkobling"

Det er bare feil (i hvert fall med alle nyere Coreutils-utgivelser).

Legg merke til at harde lenker virkelig blir ødelagt, men AFAIK tar holder ikke harde lenker riktig uansett og ødeleggelse av harde lenker vil ikke føre til at pakker ikke klarer å bygge i det hele tatt.