### PR TITLE
changingowner: Legg til --from lfs for chown root:root kommandoer

### DIFF
--- a/chapter07/changingowner.xml
+++ b/chapter07/changingowner.xml
@@ -33,9 +33,9 @@
    bruker <systemitem class="username">root</systemitem> ved å kjøre følgende
    kommando:</para>
 
-<screen><userinput>chown -R root:root $LFS/{usr,lib,var,etc,bin,sbin,tools}
+<screen><userinput>chown --from lfs -R root:root $LFS/{usr,lib,var,etc,bin,sbin,tools}
 case $(uname -m) in
-  x86_64) chown -R root:root $LFS/lib64 ;;
+  x86_64) chown --from lfs -R root:root $LFS/lib64 ;;
 esac</userinput></screen>
 
 </sect1>


### PR DESCRIPTION
Så hvis brukeren ikke har satt $LFS riktig, vil chown ikke gjøre noe i stedet skape kaos i vertsdistroen.

--from <user> har vært tilgjengelig for Coreutils chown siden 2000, så vi trenger ikke heve vertssystemkravet.