### PR TITLE
dependencies: Bison byggesystem trenger diffutils

### DIFF
--- a/appendices/dependencies.xml
+++ b/appendices/dependencies.xml
@@ -326,8 +326,8 @@
       <segmentedlist id="bison-depends">
         <segtitle>&dependencies;</segtitle>
         <seglistitem>
-          <seg>Bash, Binutils, Coreutils, GCC, Gettext, Glibc, Grep, M4, Make,
-          Perl, og Sed</seg>
+          <seg>Bash, Binutils, Coreutils, Diffutils, GCC, Gettext, Glibc,
+          Grep, M4, Make, Perl, og Sed</seg>
         </seglistitem>
       </segmentedlist>
 


### PR DESCRIPTION
En nylig lfs-støttediskusjon avslørte om diffutils er glemt, bison byggesystem kan mislykkes på en måte som er svært vanskelig å diagnostisere.