### PR TITLE
coreutils: Legg til -k for make check

### DIFF
--- a/chapter08/coreutils.xml
+++ b/chapter08/coreutils.xml
@@ -127,7 +127,8 @@ FORCE_UNSAFE_CONFIGURE=1 ./configure \
     for en slik PTY kan ikke nås fra LFS chroot
     miljøet):</para>
 
-<screen><userinput remap="test">su tester -c "PATH=$PATH make RUN_EXPENSIVE_TESTS=yes check" &lt; /dev/null</userinput></screen>
+<screen><userinput remap="test">su tester -c "PATH=$PATH make -k RUN_EXPENSIVE_TESTS=yes check" \
+   &lt; /dev/null</userinput></screen>
 
     <para>Fjern den midlertidige gruppen:</para>
 


### PR DESCRIPTION
To tester er kjent for å mislykkes, så uten -k er en del av testpakken ikke utført.