### PR TITLE
gcc pass2: --disable-libsanitizer er ikke lenger strengt nødvendig

### DIFF
--- a/appendices/dependencies.xml
+++ b/appendices/dependencies.xml
@@ -935,7 +935,7 @@
         <segtitle>&dependencies;</segtitle>
         <seglistitem>
           <seg>Bash, Binutils, Coreutils, Diffutils, Findutils, Gawk, GCC,
-          Gettext, Glibc, GMP, Grep, Libxcrypt, M4, Make, MPC, MPFR, Patch,
+          Gettext, Glibc, GMP, Grep, M4, Make, MPC, MPFR, Patch,
           Perl, Sed, Tar, Texinfo, og Zstd</seg>
         </seglistitem>
       </segmentedlist>
@@ -1887,7 +1887,7 @@
       <segmentedlist id="libxcrypt-before">
         <segtitle>&before;</segtitle>
         <seglistitem>
-          <seg>GCC, Perl, Python, Shadow, og &systemd-udev;</seg>
+          <seg>Perl, Python, Shadow, og &systemd-udev;</seg>
         </seglistitem>
       </segmentedlist>
 

--- a/chapter06/gcc-pass2.xml
+++ b/chapter06/gcc-pass2.xml
@@ -149,12 +149,10 @@ cd       build</userinput></screen>
         <term><parameter>--disable-libsanitizer</parameter></term>
         <listitem>
           <para>Deaktiver GCC rensende kjøretidsbiblioteker. De er ikke
-          nødvendig for den midlertidige installasjonen. Denne bryteren er nødvendig
-          for å bygge GCC uten
-          <systemitem class='library'>libcrypt</systemitem> installert for
-          målet. I <xref linkend='ch-tools-gcc-pass1'/> det var
-          underforstått ved <parameter>--disable-libstdcxx</parameter>, men nå
-          må vi eksplisitt angi det.</para>
+          nødvendig for den midlertidige installasjonen.  I
+          <xref linkend='ch-tools-gcc-pass1'/> det ble antydet av
+          <parameter>--disable-libstdcxx</parameter>, og nå kan vi
+          gi den eksplisitt.</para>
         </listitem>
       </varlistentry>
 


### PR DESCRIPTION
GCC 14 libsanitizer er ikke lenger avhengig av crypt.h. Men la oss beholde denne muligheten for å redusere byggetiden, bare oppdater forklaringen.

Fjern også libxcrypt fra GCC avhengighetslisten.