### PR TITLE
bootscripts: console: Fiks fb konsolldeteksjon

### DIFF
--- a/bootscripts/ChangeLog
+++ b/bootscripts/ChangeLog
@@ -1,3 +1,9 @@
+2024-08-23 Xi Ruoyao <xry111@xry111.site>
+   * In console, detect FB console by checking /sys/class/graphics/fbcon
+     instead of fb0.  The latter does not exist if CONFIG_FB=n, but
+     CONFIG_DRM_FBDEV_EMULATION=y can support a FB console without
+     CONFIG_FB.
+
 2024-07-12 Xi Ruoyao <xry111@xry111.site>
    * In mountvirtfs, recreate /dev/fd correctly if it's already created
      by the initramfs.

--- a/bootscripts/lfs/init.d/console
+++ b/bootscripts/lfs/init.d/console
@@ -47,7 +47,7 @@ case "${1}" in
       log_info_msg "Setting up Linux console..."
 
       # Figure out if a framebuffer console is used
-      [ -d /sys/class/graphics/fb0 ] && use_fb=1 || use_fb=0
+      [ -d /sys/class/graphics/fbcon ] && use_fb=1 || use_fb=0
 
       # Figure out the command to set the console into the
       # desired mode

--- a/chapter01/changelog.xml
+++ b/chapter01/changelog.xml
@@ -41,6 +41,17 @@
     -->
 
     <listitem>
+      <para>23.08.2024</para>
+      <itemizedlist>
+        <listitem>
+          <para>[xry111] - Oppdater til lfs-bootscripts-20240823 for å fikse et
+          problem som forårsaker at VT 2-6 ikke påvirkes av FONT= innstillingen i
+          /etc/sysconfig/console.</para>
+        </listitem>
+      </itemizedlist>
+    </listitem>
+
+    <listitem>
       <para>17.08.2024</para>
       <itemizedlist>
         <listitem>

--- a/packages.ent
+++ b/packages.ent
@@ -381,7 +381,7 @@
 <!ENTITY less-fin-du "14 MB">
 <!ENTITY less-fin-sbu "mindre enn 0.1 SBU">
 
-<!ENTITY lfs-bootscripts-version "20240717">      <!-- Scripts depend on this format -->
+<!ENTITY lfs-bootscripts-version "20240823">      <!-- Scripts depend on this format -->
 <!ENTITY lfs-bootscripts-size "BOOTSCRIPTS-SIZE KB">
 <!ENTITY lfs-bootscripts-url "&downloads-root;lfs-bootscripts-&lfs-bootscripts-version;.tar.xz">
 <!ENTITY lfs-bootscripts-md5 "BOOTSCRIPTS-MD5SUM">


### PR DESCRIPTION
Hvis CONFIG_FB ikke er satt, men CONFIG_DRM_FBDEV_EMULATION er satt til y, på en DRM-drevet grafikkort (alt fra AMD/ATI, Intel eller NVIDIA i siste 20 årene) ville vi brukt en fb-konsoll, men uten /sys/class/graphics/fb0. Da vil ikke skriptet kjøre setfont for VT 2-6.

Merk av /sys/class/graphics/fbcon i stedet for /sys/class/graphics/fb0 for å fikse problemet.