### PR TITLE
Pakkeoppdateringer

### DIFF
--- a/chapter01/changelog.xml
+++ b/chapter01/changelog.xml
@@ -40,7 +40,55 @@
     appropriate for the entry or if needed the entire day's listitem.
     -->
 
-    <listitem>
+        <listitem>
+      <para>07.09.2024</para>
+      <itemizedlist>
+        <listitem>
+          <para>[bdubbs] - Oppdater til tzdata-2024b. Fikser
+          <ulink url='&lfs-ticket-root;5554'>#5554</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdater til systemd-256.5. Fikser
+          <ulink url='&lfs-ticket-root;5551'>#5551</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdater til setuptools-74.1.2. Fikser
+          <ulink url='&lfs-ticket-root;5546'>#5546</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdater til python3-3.12.6. Fikser
+          <ulink url='&lfs-ticket-root;5555'>#5555</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdater til openssl-3.3.2. Fikser
+          <ulink url='&lfs-ticket-root;5552'>#5552</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdater til man-db-2.13.0. Fikser
+          <ulink url='&lfs-ticket-root;5550'>#5550</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdater til linux-6.10.8. Fikser
+          <ulink url='&lfs-ticket-root;5545'>#5545</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdater til libpipeline-1.5.8. Fikser
+          <ulink url='&lfs-ticket-root;5548'>#5548</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdater til expat-2.6.3. Fikser
+          <ulink url='&lfs-ticket-root;5553'>#5553</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdater til bc-7.0.1. Fikser
+          <ulink url='&lfs-ticket-root;5547'>#5547</ulink>.</para>
+        </listitem>
+      </itemizedlist>
+    </listitem>
+
+
+
+	<listitem>
       <para>01.09.2024</para>
       <itemizedlist>
         <listitem>

--- a/chapter01/whatsnew.xml
+++ b/chapter01/whatsnew.xml
@@ -41,9 +41,9 @@
     <!--<listitem>
       <para>Bash-&bash-version;</para>
     </listitem>-->
-    <!--<listitem>
+    <listitem>
       <para>Bc-&bc-version;</para>
-    </listitem>-->
+    </listitem>
     <!--<listitem>
       <para>Binutils-&binutils-version;</para>
     </listitem>-->
@@ -71,9 +71,9 @@
     <!--<listitem>
        <para>E2fsprogs-&e2fsprogs-version;</para>
     </listitem>-->
-    <!--<listitem>
+    <listitem>
        <para>Expat-&expat-version;</para>
-    </listitem>-->
+    </listitem>
     <!--<listitem>
        <para>Expect-&expect-version;</para>
     </listitem>-->
@@ -122,9 +122,9 @@
     <!--<listitem>
       <para>Gzip-&gzip-version;</para>
     </listitem>-->
-    <!--<listitem>
+    <listitem>
       <para>Iana-Etc-&iana-etc-version;</para>
-    </listitem>-->
+    </listitem>
     <!--<listitem>
       <para>Inetutils-&inetutils-version;</para>
     </listitem>-->
@@ -158,15 +158,15 @@
     <!--<listitem>
       <para>Libffi-&libffi-version;</para>
     </listitem>-->
-    <!--<listitem>
+    <listitem>
       <para>Libpipeline-&libpipeline-version;</para>
-    </listitem>-->
+    </listitem>
     <!--<listitem>
       <para>Libtool-&libtool-version;</para>
     </listitem>-->
-    <!--<listitem>
+    <listitem>
       <para>Linux-&linux-version;</para>
-    </listitem>-->
+    </listitem>
     <!--<listitem>
       <para>Lz4-&lz4-version;</para>
     </listitem>-->
@@ -176,9 +176,9 @@
     <!--<listitem>
       <para>Make-&make-version;</para>
     </listitem>-->
-    <!--<listitem>
+    <listitem>
       <para>Man-DB-&man-db-version;</para>
-    </listitem>-->
+    </listitem>
     <!--<listitem>
       <para>Man-pages-&man-pages-version;</para>
     </listitem>-->
@@ -200,9 +200,9 @@
     <!--<listitem>
       <para>Ninja-&ninja-version;</para>
     </listitem>-->
-    <!--<listitem>
+    <listitem>
       <para>OpenSSL-&openssl-version;</para>
-    </listitem>-->
+    </listitem>
     <!--<listitem>
       <para>Patch-&patch-version;</para>
     </listitem>-->
@@ -218,27 +218,27 @@
     <!--<listitem>
       <para>Psmisc-&psmisc-version;</para>
     </listitem>-->
-    <!--<listitem>
+    <listitem>
       <para>Python-&python-version;</para>
-    </listitem>-->
+    </listitem>
     <!--<listitem>
       <para>Readline-&readline-version;</para>
     </listitem>-->
     <!--<listitem>
       <para>Sed-&sed-version;</para>
     </listitem>-->
-    <!--<listitem>
+    <listitem>
       <para>Setuptools-&setuptools-version;</para>
-    </listitem>-->
+    </listitem>
     <!--<listitem>
       <para>Shadow-&shadow-version;</para>
     </listitem>-->
     <!--<listitem revision="sysv">
       <para>Sysklogd-&sysklogd-version;</para>
     </listitem>-->
-    <!--<listitem>
+    <listitem>
       <para>Systemd-&systemd-version;</para>
-    </listitem>-->
+    </listitem>
     <!--<listitem revision="sysv">
       <para>SysVinit-&sysvinit-version;</para>
     </listitem>-->
@@ -251,12 +251,12 @@
     <!--<listitem>
       <para>Texinfo-&texinfo-version;</para>
     </listitem>-->
-    <!--<listitem>
+    <listitem>
       <para>Tzdata-&tzdata-version;</para>
-    </listitem>-->
-    <!--<listitem revision="sysv">
+    </listitem>
+    <listitem revision="sysv">
       <para>Udev from Systemd-&systemd-version;</para>
-    </listitem>-->
+    </listitem>
     <!--<listitem>
       <para>Util-linux-&util-linux-version;</para>
     </listitem>-->

--- a/packages.ent
+++ b/packages.ent
@@ -57,10 +57,10 @@
 <!ENTITY bash-fin-du "52 MB">
 <!ENTITY bash-fin-sbu "1.4 SBU">
 
-<!ENTITY bc-version "6.7.6">
-<!ENTITY bc-size "463 KB">
+<!ENTITY bc-version "7.0.1">
+<!ENTITY bc-size "464 KB">
 <!ENTITY bc-url "https://github.com/gavinhoward/bc/releases/download/&bc-version;/bc-&bc-version;.tar.xz">
-<!ENTITY bc-md5 "a47aa5e4e7395fbcd159a9228613b97b">
+<!ENTITY bc-md5 "3dbcb9f4642dd070c64844b6afd5f108">
 <!ENTITY bc-home "https://git.gavinhoward.com/gavin/bc">
 <!ENTITY bc-fin-du "7.8 MB">
 <!ENTITY bc-fin-sbu "mindre enn 0.1 SBU">
@@ -156,10 +156,10 @@
 <!ENTITY elfutils-fin-du "127 MB">
 <!ENTITY elfutils-fin-sbu "0.3 SBU">
 
-<!ENTITY expat-version "2.6.2">
-<!ENTITY expat-size "474 KB">
+<!ENTITY expat-version "2.6.3">
+<!ENTITY expat-size "475 KB">
 <!ENTITY expat-url "&sourceforge;expat/expat-&expat-version;.tar.xz">
-<!ENTITY expat-md5 "0cb75c8feb842c0794ba89666b762a2d">
+<!ENTITY expat-md5 "3812d9fe29a5a6d64de3fa6e6509fdad">
 <!ENTITY expat-home "https://libexpat.github.io/">
 <!ENTITY expat-fin-du "13 MB">
 <!ENTITY expat-fin-sbu "0.1 SBU">
@@ -317,10 +317,10 @@
 <!ENTITY gzip-fin-du "21 MB">
 <!ENTITY gzip-fin-sbu "0.3 SBU">
 
-<!ENTITY iana-etc-version "20240806">
+<!ENTITY iana-etc-version "20240829">
 <!ENTITY iana-etc-size "590 KB">
 <!ENTITY iana-etc-url "https://github.com/Mic92/iana-etc/releases/download/&iana-etc-version;/iana-etc-&iana-etc-version;.tar.gz">
-<!ENTITY iana-etc-md5 "ea3c37c00d22f1159fc3b7d988de8476">
+<!ENTITY iana-etc-md5 "93a1f39dfed9ef58901c3255a66310a4">
 <!ENTITY iana-etc-home "https://www.iana.org/protocols">
 <!ENTITY iana-etc-fin-du "4.8 MB">
 <!ENTITY iana-etc-fin-sbu "mindre enn 0.1 SBU">
@@ -405,10 +405,10 @@
 <!ENTITY libffi-fin-du "11 MB">
 <!ENTITY libffi-fin-sbu "1.7 SBU">
 
-<!ENTITY libpipeline-version "1.5.7">
-<!ENTITY libpipeline-size "956 KB">
+<!ENTITY libpipeline-version "1.5.8">
+<!ENTITY libpipeline-size "1046 KB">
 <!ENTITY libpipeline-url "&savannah;/releases/libpipeline/libpipeline-&libpipeline-version;.tar.gz">
-<!ENTITY libpipeline-md5 "1a48b5771b9f6c790fb4efdb1ac71342">
+<!ENTITY libpipeline-md5 "17ac6969b2015386bcb5d278a08a40b5">
 <!ENTITY libpipeline-home "https://libpipeline.nongnu.org/">
 <!ENTITY libpipeline-fin-du "9.7 MB">
 <!ENTITY libpipeline-fin-sbu "0.1 SBU">
@@ -431,12 +431,12 @@
 
 <!ENTITY linux-major-version "6">
 <!ENTITY linux-minor-version "10">
-<!ENTITY linux-patch-version "5">
+<!ENTITY linux-patch-version "8">
 <!--<!ENTITY linux-version "&linux-major-version;.&linux-minor-version;">-->
 <!ENTITY linux-version "&linux-major-version;.&linux-minor-version;.&linux-patch-version;">
-<!ENTITY linux-size "141,739 KB">
+<!ENTITY linux-size "141,755 KB">
 <!ENTITY linux-url "&kernel;linux/kernel/v&linux-major-version;.x/linux-&linux-version;.tar.xz">
-<!ENTITY linux-md5 "276ef1f11ed3713ec5d6f506ff55ac12">
+<!ENTITY linux-md5 "e449666908b3ddf351c8faaa1d511be2">
 <!ENTITY linux-home "https://www.kernel.org/">
 <!-- measured for 6.10.1 / gcc-14.1.0 on x86_64 with -j4 : 
  minimum is allnoconfig 
@@ -479,10 +479,10 @@
 <!ENTITY make-fin-du "13 MB">
 <!ENTITY make-fin-sbu "0.7 SBU">
 
-<!ENTITY man-db-version "2.12.1">
-<!ENTITY man-db-size "1,994 KB">
+<!ENTITY man-db-version "2.13.0">
+<!ENTITY man-db-size "2,023 KB">
 <!ENTITY man-db-url "&savannah;/releases/man-db/man-db-&man-db-version;.tar.xz">
-<!ENTITY man-db-md5 "7b044e5020aab89db41ac7ee59d6d84a">
+<!ENTITY man-db-md5 "97ab5f9f32914eef2062d867381d8cee">
 <!ENTITY man-db-home "https://www.nongnu.org/man-db/">
 <!ENTITY man-db-fin-du "43 MB">
 <!ENTITY man-db-fin-sbu "0.3 SBU">
@@ -545,10 +545,10 @@
 <!ENTITY ninja-fin-du "37 MB">
 <!ENTITY ninja-fin-sbu "0.2 SBU">
 
-<!ENTITY openssl-version "3.3.1">
-<!ENTITY openssl-size "17,633 KB">
+<!ENTITY openssl-version "3.3.2">
+<!ENTITY openssl-size "17,653 KB">
 <!ENTITY openssl-url "https://www.openssl.org/source/openssl-&openssl-version;.tar.gz">
-<!ENTITY openssl-md5 "8a4342b399c18f870ca6186299195984">
+<!ENTITY openssl-md5 "015fca2692596560b6fe8a2d8fecd84b">
 <!ENTITY openssl-home "https://www.openssl-library.org/">
 <!ENTITY openssl-fin-du "883 MB">
 <!ENTITY openssl-fin-sbu "1.7 SBU">
@@ -604,19 +604,19 @@
 <!-- If python minor version changes, updates in python and
      meson pages will be needed: python3.6 and python3.6m -->
 
-<!ENTITY python-version "3.12.5">
+<!ENTITY python-version "3.12.6">
 <!ENTITY python-minor "3.12">
-<!ENTITY python-size "19,944 KB">
+<!ENTITY python-size "19,956 KB">
 <!ENTITY python-url "https://www.python.org/ftp/python/&python-version;/Python-&python-version;.tar.xz">
-<!ENTITY python-md5 "02c7d269e077f4034963bba6befdc715">
+<!ENTITY python-md5 "cb669514937d3e894e74081627722aa5">
 <!ENTITY python-home "https://www.python.org/">
 <!ENTITY python-tmp-du "603 MB">
 <!ENTITY python-tmp-sbu "0.4 SBU">
 <!ENTITY python-fin-du "530 MB">
 <!ENTITY python-fin-sbu "2.2 SBU">
 <!ENTITY python-docs-url "https://www.python.org/ftp/python/doc/&python-version;/python-&python-version;-docs-html.tar.bz2">
-<!ENTITY python-docs-md5 "52274d813236ca4a972fb6988480dc56">
-<!ENTITY python-docs-size "8,188 KB">
+<!ENTITY python-docs-md5 "35e90037a10d51af0c396b05bd64659d">
+<!ENTITY python-docs-size "8,165 KB">
 
 <!ENTITY readline-version "8.2.13">
 <!ENTITY readline-soversion "8.2"><!-- used for stripping -->
@@ -637,10 +637,10 @@
 <!ENTITY sed-fin-du "30 MB">
 <!ENTITY sed-fin-sbu "0.3 SBU">
 
-<!ENTITY setuptools-version "72.2.0">
-<!ENTITY setuptools-size "2,363 KB">
+<!ENTITY setuptools-version "74.1.2">
+<!ENTITY setuptools-size "1,325 KB">
 <!ENTITY setuptools-url "&pypi-src;/s/setuptools/setuptools-&setuptools-version;.tar.gz">
-<!ENTITY setuptools-md5 "2e0ffd0f6fc632a11442b79d9b1c68bd">
+<!ENTITY setuptools-md5 "dade67d5cb658dfb31c1ec7e0186426e">
 <!ENTITY setuptools-home "&pypi-home;/setuptools/">
 <!ENTITY setuptools-fin-du "35 MB">
 <!ENTITY setuptools-fin-sbu "mindre enn 0.1 SBU">
@@ -661,21 +661,21 @@
 <!ENTITY sysklogd-fin-du "3.9 MB">
 <!ENTITY sysklogd-fin-sbu "mindre enn 0.1 SBU">
 
-<!ENTITY systemd-version  "256.4">
+<!ENTITY systemd-version  "256.5">
 <!--<!ENTITY systemd-stable   "6b4878d">-->
 <!-- The above entity is used whenever we move to a stable backport branch. 
      In the event of a critical problem or kernel change that is incompatible, 
      we will switch to the backport branch until the next stable release. -->
-<!ENTITY systemd-size     "15,291 KB">
+<!ENTITY systemd-size     "15,298 KB">
 <!ENTITY systemd-url      "&github;/systemd/systemd/archive/v&systemd-version;/systemd-&systemd-version;.tar.gz">
 <!--<!ENTITY systemd-url      "&anduin-sources;/systemd-&systemd-version;-&systemd-stable;.tar.xz">-->
-<!ENTITY systemd-md5      "03bd1ff158ec0bc55428c77a8f8495bd">
+<!ENTITY systemd-md5      "846a8b47a235793d0f937dfc53cfb78f">
 <!ENTITY systemd-home     "https://www.freedesktop.org/wiki/Software/systemd/">
-<!ENTITY systemd-man-version "256.4">
-<!ENTITY systemd-man-size "676 KB">
+<!ENTITY systemd-man-version "256.5">
+<!ENTITY systemd-man-size "717 KB">
 <!--<!ENTITY systemd-man-url  "&anduin-sources;/systemd-man-pages-&systemd-version;-&systemd-stable;.tar.xz">-->
 <!ENTITY systemd-man-url  "&anduin-sources;/systemd-man-pages-&systemd-man-version;.tar.xz">
-<!ENTITY systemd-man-md5  "8dbcf0ff0d8e5e9d3565f9d2fc153310">
+<!ENTITY systemd-man-md5  "4965bf4bf74cb616ac394459158a5d27">
 <!ENTITY systemd-fin-du   "267 MB">
 <!ENTITY systemd-fin-sbu  "0.8 SBU">
 
@@ -719,10 +719,10 @@
 <!ENTITY texinfo-fin-du "139 MB">
 <!ENTITY texinfo-fin-sbu "0.3 SBU">
 
-<!ENTITY tzdata-version "2024a">
-<!ENTITY tzdata-size "444 KB">
+<!ENTITY tzdata-version "2024b">
+<!ENTITY tzdata-size "449 KB">
 <!ENTITY tzdata-url "https://www.iana.org/time-zones/repository/releases/tzdata&tzdata-version;.tar.gz">
-<!ENTITY tzdata-md5 "2349edd8335245525cc082f2755d5bf4">
+<!ENTITY tzdata-md5 "e1d010b46844502f12dcff298c1b7154">
 <!ENTITY tzdata-home "https://www.iana.org/time-zones">
 
 <!ENTITY udev-fin-du "144 MB">


### PR DESCRIPTION
Oppdatering til tzdata-2024b. Oppdatering til systemd-256.5. Oppdatering til setuptools-74.1.2. Oppdatering til Python3-3.12.6. Oppdatering til openssl-3.3.2. Oppdatering til man-db-2.13.0. Oppdatering til linux-6.10.8. Oppdatering til libpipeline-1.5.8. Oppdatering til expat-2.6.3. Oppdatering til bc-7.0.1.