### PR TITLE
Pakkeoppdateringer

### DIFF
--- a/chapter01/changelog.xml
+++ b/chapter01/changelog.xml
@@ -41,6 +41,40 @@
     -->
 
     <listitem>
+      <para>01.10.2024</para>
+      <itemizedlist>
+        <listitem>
+          <para>[bdubbs] - Oppdater til Python3-3.12.7. Fikser
+          <ulink url='&lfs-ticket-root;5571'>#5571</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdater til tcl9.0.0. Fikser
+          <ulink url='&lfs-ticket-root;5570'>#5570</ulink>.</para>
+        </listitem>
+        <listitem revision="sysv">
+          <para>[bdubbs] - Oppdater til linux-6.11.1. Fikser
+          <ulink url='&lfs-ticket-root;5556'>#5556</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdater til libtool-2.5.3. Fikser
+          <ulink url='&lfs-ticket-root;5569'>#5569</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdater til iproute2-6.11.0. Fikser
+          <ulink url='&lfs-ticket-root;5561'>#5561</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdater til bash-5.2.37. Fikser
+          <ulink url='&lfs-ticket-root;5567'>#5567</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdater til bc-7.0.3. Fikser
+          <ulink url='&lfs-ticket-root;5568'>#5568</ulink>.</para>
+        </listitem>
+      </itemizedlist>
+    </listitem>
+
+    <listitem>
       <para>20.09.2024</para>
       <itemizedlist>
         <listitem>

--- a/chapter01/whatsnew.xml
+++ b/chapter01/whatsnew.xml
@@ -38,9 +38,9 @@
     <!--<listitem>
       <para>Automake-&automake-version;</para>
     </listitem>-->
-    <!--<listitem>
+    <listitem>
       <para>Bash-&bash-version;</para>
-    </listitem>-->
+    </listitem>
     <listitem>
       <para>Bc-&bc-version;</para>
     </listitem>
@@ -131,9 +131,9 @@
     <!--<listitem>
       <para>Intltool-&intltool-version;</para>
     </listitem>-->
-    <!--<listitem>
+    <listitem>
       <para>IPRoute2-&iproute2-version;</para>
-    </listitem>-->
+    </listitem>
     <!--<listitem>
       <para>Jinja2-&jinja2-version;</para>
     </listitem>-->
@@ -161,9 +161,9 @@
     <listitem>
       <para>Libpipeline-&libpipeline-version;</para>
     </listitem>
-    <!--<listitem>
+    <listitem>
       <para>Libtool-&libtool-version;</para>
-    </listitem>-->
+    </listitem>
     <listitem>
       <para>Linux-&linux-version;</para>
     </listitem>
@@ -292,17 +292,17 @@
   <itemizedlist>
     <title>Lagt til:</title>
     <listitem><para></para></listitem>  <!-- satisfy build -->
-    <!--<listitem>
-      <para>Lz4-&lz4-version;</para>
-    </listitem>-->
+    <listitem>
+      <para>expect-5.45.4-gcc14-2.patch</para>
+    </listitem>
   </itemizedlist>
 
   <itemizedlist>
     <title>Fjernet:</title>
     <listitem><para></para></listitem>  <!-- satisfy build -->
-    <!--<listitem>
-      <para>bash-5.2.21-upstream_fixes-1.patch</para>
-    </listitem>-->
+    <listitem>
+      <para>expect-5.45.4-gcc14-1.patch</para>
+    </listitem>
     <!--<listitem>
       <para>readline-8.2-upstream_fixes-3.patch</para>
     </listitem>-->

--- a/chapter08/expect.xml
+++ b/chapter08/expect.xml
@@ -69,7 +69,7 @@
 
     <para>Gjør nå noen endringer for å tillate pakken med gcc-14.1 eller nyere:</para>
 
-<screen><userinput remap="pre">patch -Np1 -i ../expect-&expect-version;-gcc14-1.patch</userinput></screen>
+<screen><userinput remap="pre">patch -Np1 -i ../expect-&expect-version;-gcc14-2.patch</userinput></screen>
 
     <para>Forbered Expect for kompilering:</para>
 

--- a/chapter08/python.xml
+++ b/chapter08/python.xml
@@ -163,7 +163,7 @@ EOF
 
 tar --no-same-owner \
     -xvf ../python-&python-version;-docs-html.tar.bz2
-cp -R --no-preserve=mode python-&python-version;-docs-html/* \
+cp -R --no-preserve=mode python-&python-minor;-docs-html/* \
     /usr/share/doc/python-&python-version;/html</userinput></screen>
 
     <variablelist>

--- a/chapter08/tcl.xml
+++ b/chapter08/tcl.xml
@@ -4,7 +4,7 @@
   <!ENTITY % general-entities SYSTEM "../general.ent">
   %general-entities;
   <!ENTITY tdbc-ver          "1.1.9">
-  <!ENTITY itcl-ver          "4.3.0">
+  <!ENTITY itcl-ver          "4.3.1">
 ]>
 
 <sect1 id="ch-system-tcl" role="wrap">
@@ -75,7 +75,7 @@ cd unix
 
     <para>Bygg pakken:</para>
 
-<screen><userinput remap="make">make
+<screen><userinput remap="make">make NATIVE_ZIP=$PWD/minizip
 
 sed -e "s|$SRCDIR/unix|/usr/lib|" \
     -e "s|$SRCDIR|/usr/include|"  \
@@ -103,6 +103,8 @@ unset SRCDIR</userinput></screen>
     <para>For å teste resultatene, kjør:</para>
 
 <screen><userinput remap="test">make test</userinput></screen>
+
+    <para>Tolv tester er kjent for å mislykkes i chroot miljøet.</para>
 
     <para>Installer pakken:</para>
 

--- a/packages.ent
+++ b/packages.ent
@@ -47,20 +47,20 @@
 <!ENTITY automake-fin-du "121 MB">
 <!ENTITY automake-fin-sbu "mindre enn 0.1 SBU (omtrent 1.1 SBU med tester)">
 
-<!ENTITY bash-version "5.2.32">
-<!ENTITY bash-size "10,697 KB">
+<!ENTITY bash-version "5.2.37">
+<!ENTITY bash-size "10,868 KB">
 <!ENTITY bash-url "&gnu;bash/bash-&bash-version;.tar.gz">
-<!ENTITY bash-md5 "f204835b2e06c06e37b5ad776ff907f4">
+<!ENTITY bash-md5 "9c28f21ff65de72ca329c1779684a972">
 <!ENTITY bash-home "&gnu-software;bash/">
 <!ENTITY bash-tmp-du "67 MB">
 <!ENTITY bash-tmp-sbu "0.2 SBU">
 <!ENTITY bash-fin-du "52 MB">
 <!ENTITY bash-fin-sbu "1.4 SBU">
 
-<!ENTITY bc-version "7.0.2">
+<!ENTITY bc-version "7.0.3">
 <!ENTITY bc-size "464 KB">
 <!ENTITY bc-url "https://github.com/gavinhoward/bc/releases/download/&bc-version;/bc-&bc-version;.tar.xz">
-<!ENTITY bc-md5 "7425c5fde4fcd86db544d376ff8fcfc8">
+<!ENTITY bc-md5 "ad4db5a0eb4fdbb3f6813be4b6b3da74">
 <!ENTITY bc-home "https://git.gavinhoward.com/gavin/bc">
 <!ENTITY bc-fin-du "7.8 MB">
 <!ENTITY bc-fin-sbu "mindre enn 0.1 SBU">
@@ -341,10 +341,10 @@
 <!ENTITY intltool-fin-du "1.5 MB">
 <!ENTITY intltool-fin-sbu "mindre enn 0.1 SBU">
 
-<!ENTITY iproute2-version "6.10.0">
-<!ENTITY iproute2-size "900 KB">
+<!ENTITY iproute2-version "6.11.0">
+<!ENTITY iproute2-size "903 KB">
 <!ENTITY iproute2-url "&kernel;linux/utils/net/iproute2/iproute2-&iproute2-version;.tar.xz">
-<!ENTITY iproute2-md5 "6282e47de9c5b230e83537fba7181c9c">
+<!ENTITY iproute2-md5 "9d7927e8e5ca301bd14990f64ad44a8c">
 <!ENTITY iproute2-home "&kernel;linux/utils/net/iproute2/">
 <!ENTITY iproute2-fin-du "17 MB">
 <!ENTITY iproute2-fin-sbu "0.1 SBU">
@@ -413,10 +413,10 @@
 <!ENTITY libpipeline-fin-du "9.7 MB">
 <!ENTITY libpipeline-fin-sbu "0.1 SBU">
 
-<!ENTITY libtool-version "2.4.7">
-<!ENTITY libtool-size "996 KB">
+<!ENTITY libtool-version "2.5.3">
+<!ENTITY libtool-size "1,026 KB">
 <!ENTITY libtool-url "&gnu;libtool/libtool-&libtool-version;.tar.xz">
-<!ENTITY libtool-md5 "2fc0b6ddcd66a89ed6e45db28fa44232">
+<!ENTITY libtool-md5 "e42b7d9ab875f1d013bba3cdb8a59b58">
 <!ENTITY libtool-home "&gnu-software;libtool/">
 <!ENTITY libtool-fin-du "45 MB">
 <!ENTITY libtool-fin-sbu "0.8 SBU">
@@ -430,13 +430,13 @@
 <!ENTITY libxcrypt-fin-sbu "0.1 SBU">
 
 <!ENTITY linux-major-version "6">
-<!ENTITY linux-minor-version "10">
-<!ENTITY linux-patch-version "8">
+<!ENTITY linux-minor-version "11">
+<!ENTITY linux-patch-version "1">
 <!--<!ENTITY linux-version "&linux-major-version;.&linux-minor-version;">-->
 <!ENTITY linux-version "&linux-major-version;.&linux-minor-version;.&linux-patch-version;">
-<!ENTITY linux-size "141,755 KB">
+<!ENTITY linux-size "143,488 KB">
 <!ENTITY linux-url "&kernel;linux/kernel/v&linux-major-version;.x/linux-&linux-version;.tar.xz">
-<!ENTITY linux-md5 "e449666908b3ddf351c8faaa1d511be2">
+<!ENTITY linux-md5 "28d4c44c62414ef7f0c8aa1fd5667937">
 <!ENTITY linux-home "https://www.kernel.org/">
 <!-- measured for 6.10.1 / gcc-14.1.0 on x86_64 with -j4 : 
  minimum is allnoconfig 
@@ -604,19 +604,19 @@
 <!-- If python minor version changes, updates in python and
      meson pages will be needed: python3.6 and python3.6m -->
 
-<!ENTITY python-version "3.12.6">
+<!ENTITY python-version "3.12.7">
 <!ENTITY python-minor "3.12">
-<!ENTITY python-size "19,956 KB">
+<!ENTITY python-size "19,965 KB">
 <!ENTITY python-url "https://www.python.org/ftp/python/&python-version;/Python-&python-version;.tar.xz">
-<!ENTITY python-md5 "cb669514937d3e894e74081627722aa5">
+<!ENTITY python-md5 "c6c933c1a0db52597cb45a7910490f93">
 <!ENTITY python-home "https://www.python.org/">
 <!ENTITY python-tmp-du "603 MB">
 <!ENTITY python-tmp-sbu "0.4 SBU">
 <!ENTITY python-fin-du "530 MB">
 <!ENTITY python-fin-sbu "2.2 SBU">
 <!ENTITY python-docs-url "https://www.python.org/ftp/python/doc/&python-version;/python-&python-version;-docs-html.tar.bz2">
-<!ENTITY python-docs-md5 "35e90037a10d51af0c396b05bd64659d">
-<!ENTITY python-docs-size "8,165 KB">
+<!ENTITY python-docs-md5 "dc8310645d00143661062779196e551e">
+<!ENTITY python-docs-size "8,194 KB">
 
 <!ENTITY readline-version "8.2.13">
 <!ENTITY readline-soversion "8.2"><!-- used for stripping -->
@@ -697,15 +697,15 @@
 <!ENTITY tar-fin-du "43 MB">
 <!ENTITY tar-fin-sbu "0.7 SBU">
 
-<!ENTITY tcl-version "8.6.15">
-<!ENTITY tcl-major-version "8.6">
-<!ENTITY tcl-size "11,490 KB">
+<!ENTITY tcl-version "9.0.0">
+<!ENTITY tcl-major-version "9.0">
+<!ENTITY tcl-size "11,377 KB">
 <!ENTITY tcl-url "https://downloads.sourceforge.net/tcl/tcl&tcl-version;-src.tar.gz">
-<!ENTITY tcl-md5 "c13a4d5425b5ae335258342b38ba34c2">
+<!ENTITY tcl-md5 "d7a0086033f6a50218ef69ecc0e088db">
 <!ENTITY tcl-home "https://tcl.sourceforge.net/">
 <!ENTITY tcl-docs-url "https://downloads.sourceforge.net/tcl/tcl&tcl-version;-html.tar.gz">
-<!ENTITY tcl-docs-md5 "146d6317a5318ad79d4c1421ba612fe9">
-<!ENTITY tcl-docs-size "1,169 KB">
+<!ENTITY tcl-docs-md5 "94d50af62ecd72e041da5b4b06f8d051">
+<!ENTITY tcl-docs-size "1,290 KB">
 <!ENTITY tcl-tmp-du "91 MB">
 <!ENTITY tcl-tmp-sbu "3.2 SBU">
 

--- a/patches.ent
+++ b/patches.ent
@@ -15,9 +15,9 @@
 <!ENTITY coreutils-i18n-patch-md5 "58961caf5bbdb02462591fa506c73b6d">
 <!ENTITY coreutils-i18n-patch-size "164 KB">
 
-<!ENTITY expect-gcc14-patch "expect-&expect-version;-gcc14-1.patch">
-<!ENTITY expect-gcc14-patch-md5 "0b8b5ac411d011263ad40b0664c669f0">
-<!ENTITY expect-gcc14-patch-size "7.8 KB">
+<!ENTITY expect-gcc14-patch "expect-&expect-version;-gcc14-2.patch">
+<!ENTITY expect-gcc14-patch-md5 "143bfb39cf5647631e2272d6340ee280">
+<!ENTITY expect-gcc14-patch-size "48 KB">
 
 <!ENTITY glibc-fhs-patch "glibc-&glibc-version;-fhs-1.patch">
 <!ENTITY glibc-fhs-patch-md5 "9a5997c3452909b1769918c759eff8a2">


### PR DESCRIPTION
Oppdater til Python3-3.12.7. Oppdater til tcl9.0.0. Oppdater til Linux-6.11.1. Oppdater til libtool-2.5.3. Oppdater til iproute2-6.11.0. Oppdater til bash-5.2.37. Oppdater til bc-7.0.3.