### PR TITLE
Pakkeoppdateringer

### DIFF
--- a/chapter01/changelog.xml
+++ b/chapter01/changelog.xml
@@ -41,6 +41,60 @@
     -->
 
     <listitem>
+      <para>25.10.2024</para>
+      <itemizedlist>
+        <listitem>
+          <para>[bdubbs] - Oppdater til iana-etc-20241015. Adresserer
+          <ulink url='&lfs-ticket-root;5006'>#5006</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdater til vim-9.1.0813. Adresserer
+          <ulink url='&lfs-ticket-root;4500'>#4500</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdater til xz-5.6.3. Fikser
+          <ulink url='&lfs-ticket-root;5572'>#5572</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdater til sysvinit-3.11. Fikser
+          <ulink url='&lfs-ticket-root;5581'>#5581</ulink>.</para>
+        </listitem>
+        <listitem revision="sysv">
+          <para>[bdubbs] - Oppdater til setuptools-75.2.0. Fikser
+          <ulink url='&lfs-ticket-root;5577'>#5577</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdater til Python3-3.13.0. Fikser
+          <ulink url='&lfs-ticket-root;5575'>#5575</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdater til openssl-3.4.0. Fikser
+          <ulink url='&lfs-ticket-root;5582'>#5582</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdater til meson-1.6.0. Fikser
+          <ulink url='&lfs-ticket-root;5580'>#5580</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdater til markupsafe-3.0.2. Fikser
+          <ulink url='&lfs-ticket-root;5576'>#5576</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdater til linux-6.11.5. Fikser
+          <ulink url='&lfs-ticket-root;5574'>#5574</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdater til less-668. Fikser
+          <ulink url='&lfs-ticket-root;5578'>#5578</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdater til elfutils-0.192. Fikser
+          <ulink url='&lfs-ticket-root;5579'>#5579</ulink>.</para>
+        </listitem>
+      </itemizedlist>
+    </listitem>
+
+    <listitem>
       <para>03.10.2024</para>
       <itemizedlist>
         <listitem>

--- a/chapter01/whatsnew.xml
+++ b/chapter01/whatsnew.xml
@@ -143,18 +143,18 @@
     <!--<listitem>
       <para>Kmod-&kmod-version;</para>
     </listitem>-->
-    <!--<listitem>
+    <listitem>
       <para>Less-&less-version;</para>
-    </listitem>-->
+    </listitem>
     <!--<listitem>
       <para>LFS-Bootscripts-&lfs-bootscripts-version;</para>
     </listitem>-->
     <!--<listitem>
       <para>Libcap-&libcap-version;</para>
     </listitem>-->
-    <!--<listitem>
+    <listitem>
       <para>Libelf from Elfutils-&elfutils-version;</para>
-    </listitem>-->
+    </listitem>
     <!--<listitem>
       <para>Libffi-&libffi-version;</para>
     </listitem>-->
@@ -182,9 +182,9 @@
     <!--<listitem>
       <para>Man-pages-&man-pages-version;</para>
     </listitem>-->
-    <!--<listitem>
+    <listitem>
       <para>MarkupSafe-&markupsafe-version;</para>
-    </listitem>-->
+    </listitem>
     <listitem>
       <para>Meson-&meson-version;</para>
     </listitem>
@@ -239,9 +239,9 @@
     <listitem>
       <para>Systemd-&systemd-version;</para>
     </listitem>
-    <!--<listitem revision="sysv">
+    <listitem revision="sysv">
       <para>SysVinit-&sysvinit-version;</para>
-    </listitem>-->
+    </listitem>
     <!--<listitem>
       <para>Tar-&tar-version;</para>
     </listitem>-->
@@ -269,9 +269,9 @@
     <!--<listitem>
       <para>XML::Parser-&xml-parser-version;</para>
     </listitem>-->
-    <!--<listitem>
+    <listitem>
       <para>Xz-&xz-version;</para>
-    </listitem>-->
+    </listitem>
     <!--<listitem>
       <para>Zlib-&zlib-version;</para>
     </listitem>-->

--- a/chapter08/python.xml
+++ b/chapter08/python.xml
@@ -88,7 +88,8 @@
     og 1 SBU (målt når du bygger Binutils passerer 1 med én CPU
     kjerne) bør være nok. Noen tester er rare, så testpakken vil automatisk
     kjøre mislykkede tester på nytt. Hvis en test mislyktes, men deretter består
-    når den kjøres på nytt, bør den anses som bestått.</para>
+    når den kjøres på nytt, bør den anses som bestått.  En test, test_ssl,
+    er kjent for å mislykkes i chroot miljøet.</para>
 
     <para>Installer pakken:</para>
 
@@ -163,7 +164,7 @@ EOF
 
 tar --no-same-owner \
     -xvf ../python-&python-version;-docs-html.tar.bz2
-cp -R --no-preserve=mode python-&python-minor;-docs-html/* \
+cp -R --no-preserve=mode python-&python-version;-docs-html/* \
     /usr/share/doc/python-&python-version;/html</userinput></screen>
 
     <variablelist>

--- a/packages.ent
+++ b/packages.ent
@@ -148,10 +148,10 @@
 <!ENTITY e2fsprogs-fin-du "98 MB">
 <!ENTITY e2fsprogs-fin-sbu "2.4 SBU på en harddisk, 0.5 SBU på en SSD">
 
-<!ENTITY elfutils-version "0.191"> <!-- libelf -->
-<!ENTITY elfutils-size "9,092 KB">
+<!ENTITY elfutils-version "0.192"> <!-- libelf -->
+<!ENTITY elfutils-size "11,635 KB">
 <!ENTITY elfutils-url "https://sourceware.org/ftp/elfutils/&elfutils-version;/elfutils-&elfutils-version;.tar.bz2">
-<!ENTITY elfutils-md5 "636547248fb3fae58ec48030298d3ef7">
+<!ENTITY elfutils-md5 "a6bb1efc147302cfc15b5c2b827f186a">
 <!ENTITY elfutils-home "https://sourceware.org/elfutils/">
 <!ENTITY elfutils-fin-du "127 MB">
 <!ENTITY elfutils-fin-sbu "0.3 SBU">
@@ -317,10 +317,10 @@
 <!ENTITY gzip-fin-du "21 MB">
 <!ENTITY gzip-fin-sbu "0.3 SBU">
 
-<!ENTITY iana-etc-version "20240912">
+<!ENTITY iana-etc-version "20241015">
 <!ENTITY iana-etc-size "590 KB">
 <!ENTITY iana-etc-url "https://github.com/Mic92/iana-etc/releases/download/&iana-etc-version;/iana-etc-&iana-etc-version;.tar.gz">
-<!ENTITY iana-etc-md5 "c5dfa23182c74a3db8aeb5a88ac0d740">
+<!ENTITY iana-etc-md5 "5843230096950022d7a3bdf6aca5a595">
 <!ENTITY iana-etc-home "https://www.iana.org/protocols">
 <!ENTITY iana-etc-fin-du "4.8 MB">
 <!ENTITY iana-etc-fin-sbu "mindre enn 0.1 SBU">
@@ -373,10 +373,10 @@
 <!ENTITY kmod-fin-du "11 MB">
 <!ENTITY kmod-fin-sbu "mindre enn 0.1 SBU">
 
-<!ENTITY less-version "661">
-<!ENTITY less-size "634 KB">
+<!ENTITY less-version "668">
+<!ENTITY less-size "635 KB">
 <!ENTITY less-url "https://www.greenwoodsoftware.com/less/less-&less-version;.tar.gz">
-<!ENTITY less-md5 "44f54b6313c5d71fa1ac224d8d84766a">
+<!ENTITY less-md5 "d72760386c5f80702890340d2f66c302">
 <!ENTITY less-home "https://www.greenwoodsoftware.com/less/">
 <!ENTITY less-fin-du "14 MB">
 <!ENTITY less-fin-sbu "mindre enn 0.1 SBU">
@@ -431,12 +431,12 @@
 
 <!ENTITY linux-major-version "6">
 <!ENTITY linux-minor-version "11">
-<!ENTITY linux-patch-version "1">
+<!ENTITY linux-patch-version "5">
 <!--<!ENTITY linux-version "&linux-major-version;.&linux-minor-version;">-->
 <!ENTITY linux-version "&linux-major-version;.&linux-minor-version;.&linux-patch-version;">
-<!ENTITY linux-size "143,488 KB">
+<!ENTITY linux-size "143,531 KB">
 <!ENTITY linux-url "&kernel;linux/kernel/v&linux-major-version;.x/linux-&linux-version;.tar.xz">
-<!ENTITY linux-md5 "28d4c44c62414ef7f0c8aa1fd5667937">
+<!ENTITY linux-md5 "63bdafbd97203b639178e3fbd5456b54">
 <!ENTITY linux-home "https://www.kernel.org/">
 <!-- measured for 6.10.1 / gcc-14.1.0 on x86_64 with -j4 : 
  minimum is allnoconfig 
@@ -495,18 +495,18 @@
 <!ENTITY man-pages-fin-du "52 MB">
 <!ENTITY man-pages-fin-sbu "0.1 SBU">
 
-<!ENTITY markupsafe-version "2.1.5">
-<!ENTITY markupsafe-size "19 KB">
-<!ENTITY markupsafe-url "&pypi-src;/M/MarkupSafe/MarkupSafe-&markupsafe-version;.tar.gz">
-<!ENTITY markupsafe-md5 "8fe7227653f2fb9b1ffe7f9f2058998a">
+<!ENTITY markupsafe-version "3.0.2">
+<!ENTITY markupsafe-size "21 KB">
+<!ENTITY markupsafe-url "&pypi-src;/M/MarkupSafe/markupsafe-&markupsafe-version;.tar.gz">
+<!ENTITY markupsafe-md5 "cb0071711b573b155cc8f86e1de72167">
 <!ENTITY markupsafe-home "https://palletsprojects.com/p/markupsafe/">
 <!ENTITY markupsafe-fin-du "508 KB">
 <!ENTITY markupsafe-fin-sbu "mindre enn 0.1 SBU">
 
-<!ENTITY meson-version "1.5.2">
-<!ENTITY meson-size "2,213 KB">
+<!ENTITY meson-version "1.6.0">
+<!ENTITY meson-size "2,225 KB">
 <!ENTITY meson-url "&github;/mesonbuild/meson/releases/download/&meson-version;/meson-&meson-version;.tar.gz">
-<!ENTITY meson-md5 "682f75ef96c2e7542b0148e70068ea09">
+<!ENTITY meson-md5 "0031ea392f8ef97eeadfe1906c5cc5b4">
 <!ENTITY meson-home "https://mesonbuild.com">
 <!ENTITY meson-fin-du "43 MB">
 <!ENTITY meson-fin-sbu "mindre enn 0.1 SBU">
@@ -545,10 +545,10 @@
 <!ENTITY ninja-fin-du "37 MB">
 <!ENTITY ninja-fin-sbu "0.2 SBU">
 
-<!ENTITY openssl-version "3.3.2">
-<!ENTITY openssl-size "17,653 KB">
+<!ENTITY openssl-version "3.4.0">
+<!ENTITY openssl-size "17,892 KB">
 <!ENTITY openssl-url "&github;/openssl/openssl/releases/download/openssl-&openssl-version;/openssl-&openssl-version;.tar.gz">
-<!ENTITY openssl-md5 "015fca2692596560b6fe8a2d8fecd84b">
+<!ENTITY openssl-md5 "34733f7be2d60ecd8bd9ddb796e182af">
 <!ENTITY openssl-home "https://www.openssl-library.org/">
 <!ENTITY openssl-fin-du "883 MB">
 <!ENTITY openssl-fin-sbu "1.7 SBU">
@@ -604,19 +604,19 @@
 <!-- If python minor version changes, updates in python and
      meson pages will be needed: python3.6 and python3.6m -->
 
-<!ENTITY python-version "3.12.7">
-<!ENTITY python-minor "3.12">
-<!ENTITY python-size "19,965 KB">
+<!ENTITY python-version "3.13.0">
+<!ENTITY python-minor "3.13">
+<!ENTITY python-size "22,005 KB">
 <!ENTITY python-url "https://www.python.org/ftp/python/&python-version;/Python-&python-version;.tar.xz">
-<!ENTITY python-md5 "c6c933c1a0db52597cb45a7910490f93">
+<!ENTITY python-md5 "726e5b829fcf352326874c1ae599abaa">
 <!ENTITY python-home "https://www.python.org/">
 <!ENTITY python-tmp-du "603 MB">
 <!ENTITY python-tmp-sbu "0.4 SBU">
 <!ENTITY python-fin-du "530 MB">
 <!ENTITY python-fin-sbu "2.2 SBU">
 <!ENTITY python-docs-url "https://www.python.org/ftp/python/doc/&python-version;/python-&python-version;-docs-html.tar.bz2">
-<!ENTITY python-docs-md5 "dc8310645d00143661062779196e551e">
-<!ENTITY python-docs-size "8,194 KB">
+<!ENTITY python-docs-md5 "afbf0a2319b7ac7561c52969bd0f5148">
+<!ENTITY python-docs-size "9,999 KB">
 
 <!ENTITY readline-version "8.2.13">
 <!ENTITY readline-soversion "8.2"><!-- used for stripping -->
@@ -637,10 +637,10 @@
 <!ENTITY sed-fin-du "30 MB">
 <!ENTITY sed-fin-sbu "0.3 SBU">
 
-<!ENTITY setuptools-version "75.1.0">
-<!ENTITY setuptools-size "1,317 KB">
+<!ENTITY setuptools-version "75.2.0">
+<!ENTITY setuptools-size "1,319 KB">
 <!ENTITY setuptools-url "&pypi-src;/s/setuptools/setuptools-&setuptools-version;.tar.gz">
-<!ENTITY setuptools-md5 "8e8aed1625afae37b59272ff981d6e1c">
+<!ENTITY setuptools-md5 "4d69de91ce968f45825bf36d95f2a626">
 <!ENTITY setuptools-home "&pypi-home;/setuptools/">
 <!ENTITY setuptools-fin-du "35 MB">
 <!ENTITY setuptools-fin-sbu "mindre enn 0.1 SBU">
@@ -679,10 +679,10 @@
 <!ENTITY systemd-fin-du   "267 MB">
 <!ENTITY systemd-fin-sbu  "0.8 SBU">
 
-<!ENTITY sysvinit-version "3.10">
+<!ENTITY sysvinit-version "3.11">
 <!ENTITY sysvinit-size "235 KB">
 <!ENTITY sysvinit-url "&github;/slicer69/sysvinit/releases/download/&sysvinit-version;/sysvinit-&sysvinit-version;.tar.xz">
-<!ENTITY sysvinit-md5 "b8fbe11062cf16d3b6a3709b7f6978d2">
+<!ENTITY sysvinit-md5 "cb4e4bdabd902b774c4d66a85e1f6209">
 <!ENTITY sysvinit-home "&savannah-nongnu;/projects/sysvinit">
 <!ENTITY sysvinit-fin-du "2.8 MB">
 <!ENTITY sysvinit-fin-sbu "mindre enn 0.1 SBU">
@@ -745,10 +745,10 @@
 <!ENTITY util-linux-fin-du "315 MB">
 <!ENTITY util-linux-fin-sbu "0.5 SBU">
 
-<!ENTITY vim-version "9.1.0738">
+<!ENTITY vim-version "9.1.0813">
 <!-- <!ENTITY vim-majmin "90"> -->
 <!ENTITY vim-docdir "vim/vim91">
-<!ENTITY vim-size "17,673 KB">
+<!ENTITY vim-size "17,811 KB">
 <!ENTITY vim-url "https://github.com/vim/vim/archive/v&vim-version;/vim-&vim-version;.tar.gz">
 <!-- N.B. LFS 9.0 uses
      https://github.com/vim/vim/archive/v8.1.1846/vim-8.1.1846.tar.gz
@@ -762,7 +762,7 @@
      example, https://github.com/vim/vim/tags?after=v8.1.1847 will show
      us v8.1.1846. -->
 <!--<!ENTITY vim-url "&anduin-sources;/vim-&vim-version;.tar.gz">-->
-<!ENTITY vim-md5 "afe52ff64b0a3dd3644ba4aecc48737c">
+<!ENTITY vim-md5 "7cd31eb3ae6b808e5c555c63a2447ddb">
 <!ENTITY vim-home "https://www.vim.org">
 <!ENTITY vim-fin-du "245 MB">
 <!ENTITY vim-fin-sbu "2.9 SBU">
@@ -783,10 +783,10 @@
 <!ENTITY xml-parser-fin-du "2.4 MB">
 <!ENTITY xml-parser-fin-sbu "mindre enn 0.1 SBU">
 
-<!ENTITY xz-version "5.6.2">
-<!ENTITY xz-size "1,277 KB">
+<!ENTITY xz-version "5.6.3">
+<!ENTITY xz-size "1,298 KB">
 <!ENTITY xz-url "https://github.com//tukaani-project/xz/releases/download/v&xz-version;/xz-&xz-version;.tar.xz">
-<!ENTITY xz-md5 "bbf73fb28425cebb854328599f85c4cf">
+<!ENTITY xz-md5 "57581b216a82482503bb63c8170d549c">
 <!ENTITY xz-home "https://tukaani.org/xz">
 <!ENTITY xz-tmp-du "20 MB">
 <!ENTITY xz-tmp-sbu "0.1 SBU">


### PR DESCRIPTION
Oppdatering til iana-etc-20241015.
Oppdatering til vim-9.1.0813.
Oppdatering til xz-5.6.3.
Oppdatering til sysvinit-3.11.
Oppdatering til oppsettverktøy-75.2.0.
Oppdatering til Python3-3.13.0. Oppdater til openssl-3.4.0. Oppdatering til meson-1.6.0.
Oppdatering til markupsafe-3.0.2.
Oppdatering til linux-6.11.5.
Oppdater til less-668.
Oppdatering til elfutils-0.192.