### PR TITLE
vim: Fjern tester som krever curl eller vim

### DIFF
--- a/chapter08/vim.xml
+++ b/chapter08/vim.xml
@@ -65,7 +65,7 @@
     <para>For å forberede testene, sørg for at brukeren
     <systemitem class="username">tester</systemitem> kan skrive
     til kildetreet og ekskluder én fil som inneholder tester som krever
-    <command>curl</command> eller <command>wget</command>:</para></para>
+    <command>curl</command> eller <command>wget</command>:</para>
 
 <screen><userinput remap="test">chown -R tester .
 sed '/test_glvs/d' -i src/testdir/Make_all.mak</userinput></screen>

--- a/chapter08/vim.xml
+++ b/chapter08/vim.xml
@@ -64,9 +64,11 @@
 
     <para>For å forberede testene, sørg for at brukeren
     <systemitem class="username">tester</systemitem> kan skrive
-    til kildetreet:</para>
+    til kildetreet og ekskluder én fil som inneholder tester som krever
+    <command>curl</command> eller <command>wget</command>:</para></para>
 
-<screen><userinput remap="test">chown -R tester .</userinput></screen>
+<screen><userinput remap="test">chown -R tester .
+sed '/test_glvs/d' -i src/testdir/Make_all.mak</userinput></screen>
 
     <para>Kjør nå testene som bruker <systemitem
     class="username">tester</systemitem>:</para>


### PR DESCRIPTION
Siden vim-9.1.0859 trenger noen tester curl eller wget, ellers mislykkes de.