### PR TITLE
Pakkeoppdateringer og diverse rettinger.

### DIFF
--- a/chapter01/changelog.xml
+++ b/chapter01/changelog.xml
@@ -41,6 +41,48 @@
     -->
 
     <listitem>
+      <para>27.02.2025</para>
+      <itemizedlist>
+        <listitem>
+          <para>[bdubbs] - Oppdater til zstd-1.5.7.  Fikser
+          <ulink url='&lfs-ticket-root;5652'>#5652</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdater til systemd-257.3.  Fikser
+          <ulink url='&lfs-ticket-root;5612'>#5612</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdater til shadow-4.17.3.  Fikser
+          <ulink url='&lfs-ticket-root;5660'>#5660</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdater til setuptools-75.8.1.  Fikser
+          <ulink url='&lfs-ticket-root;5662'>#5662</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdater til linux-6.13.4.  Fikser
+          <ulink url='&lfs-ticket-root;5647'>#5647</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdater til kmod-34.  Fikser
+          <ulink url='&lfs-ticket-root;5657'>#5657</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdater til inetutils-2.6.  Fikser
+          <ulink url='&lfs-ticket-root;5656'>#5656</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdater til gettext-0.24.  Fikser
+          <ulink url='&lfs-ticket-root;5661'>#5661</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdater til flit_core-3.11.0.  Fikser
+          <ulink url='&lfs-ticket-root;5654'>#5654</ulink>.</para>
+        </listitem>
+      </itemizedlist>
+    </listitem>
+
+    <listitem>
       <para>24.02.2025</para>
       <itemizedlist>
         <listitem>

--- a/chapter01/whatsnew.xml
+++ b/chapter01/whatsnew.xml
@@ -125,9 +125,9 @@
     <listitem>
       <para>Iana-Etc-&iana-etc-version;</para>
     </listitem>
-    <!--<listitem>
+    <listitem>
       <para>Inetutils-&inetutils-version;</para>
-    </listitem>-->
+    </listitem>
     <!--<listitem>
       <para>Intltool-&intltool-version;</para>
     </listitem>-->
@@ -140,9 +140,9 @@
     <listitem>
       <para>Kbd-&kbd-version;</para>
     </listitem>
-    <!--<listitem>
+    <listitem>
       <para>Kmod-&kmod-version;</para>
-    </listitem>-->
+    </listitem>
     <listitem>
       <para>Less-&less-version;</para>
     </listitem>
@@ -278,9 +278,9 @@
     <!--<listitem>
       <para>Zlib-&zlib-version;</para>
     </listitem>-->
-    <!--<listitem>
+    <listitem>
       <para>Zstd-&zstd-version;</para>
-    </listitem>-->
+    </listitem>
   </itemizedlist>
 
   <!--<itemizedlist>

--- a/chapter04/addinguser.xml
+++ b/chapter04/addinguser.xml
@@ -80,7 +80,7 @@ useradd -s /bin/bash -g &lfs-groupname; -m -k /dev/null &lfs-username;</userinpu
   alle mapper under <filename class="directory">$LFS</filename> ved å gjøre
   <systemitem class="username">lfs</systemitem> eieren:</para>
 
-<screen><userinput>chown -v &lfs-username; $LFS/{usr{,/*},lib,var,etc,bin,sbin,tools}
+<screen><userinput>chown -v &lfs-username; $LFS/{usr{,/*},var,etc,tools}
 case $(uname -m) in
   x86_64) chown -v &lfs-username; $LFS/lib64 ;;
 esac</userinput></screen>

--- a/chapter08/chapter08.xml
+++ b/chapter08/chapter08.xml
@@ -60,7 +60,6 @@
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="autoconf.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="automake.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="openssl.xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="kmod.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="libelf.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="libffi.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="python.xml"/>
@@ -69,6 +68,7 @@
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="setuptools.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ninja.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="meson.xml"/>
+  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="kmod.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="coreutils.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="check.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="diffutils.xml"/>

--- a/chapter08/kmod.xml
+++ b/chapter08/kmod.xml
@@ -43,41 +43,20 @@
 
     <para>Forbered Kmod for kompilering:</para>
 
-<screen><userinput remap="configure">./configure --prefix=/usr     \
-            --sysconfdir=/etc \
-            --with-openssl    \
-            --with-xz         \
-            --with-zstd       \
-            --with-zlib       \
-            --disable-manpages</userinput></screen>
+    <screen><userinput remap="configure">mkdir -p build
+cd       build
+
+meson setup --prefix=/usr ..    \
+            --sbindir=/usr/sbin \
+            --buildtype=release \
+            -D manpages=false</userinput></screen>
 
     <variablelist>
       <title>Betydningen av konfigureringsalternativene:</title>
 
       <varlistentry>
         <term>
-          <parameter>--with-openssl</parameter>
-        </term>
-        <listitem>
-          <para>Dette alternativet gjør det mulig for Kmod å håndtere PKCS7 signaturer for
-          kjernemoduler.</para>
-        </listitem>
-      </varlistentry>
-
-      <varlistentry>
-        <term>
-          <parameter>--with-xz</parameter>,
-          <parameter>--with-zlib</parameter>, og
-          <parameter>--with-zstd</parameter>
-        </term>
-        <listitem>
-          <para>Disse alternativene gjør at Kmod kan håndtere komprimerte kjernemoduler.</para>
-        </listitem>
-      </varlistentry>
-
-      <varlistentry>
-        <term>
-          <parameter>--disable-manpages</parameter>
+          <parameter>-D manpages=false</parameter>
         </term>
         <listitem>
           <para>Dette alternativet deaktiverer generering av manualsider som
@@ -89,25 +68,15 @@
 
     <para>Kompiler pakken:</para>
 
-<screen><userinput remap="make">make</userinput></screen>
+<screen><userinput remap="make">ninja</userinput></screen>
 
     <para>Testpakken til denne pakken krever rå kjernedeklarasjoner
     (ikke de <quote>sanitiserte</quote> kjernedeklarasonene installert tidligere),
     som er utenfor rammen av LFS.</para>
 
-    <para>Installer pakken og gjenskap noen symbolkoblinger for
-    kompatibilitet med Module-Init-Tools (pakken som tidligere håndterte
-    Linux kernel moduler).  Byggesystemet vil opprette alle disse
-    symbolkoblingene i <filename class='directory'>/usr/bin</filename>, men vi
-    ønsker bare <command>lsmod</command> der og alle andre symbolkoblinger i
-    <filename class='directory'>/usr/sbin</filename> i stedet:</para>
+    <para>Installer nå pakken:</para>
 
-<screen><userinput remap="install">make install
-
-for target in depmod insmod modinfo modprobe rmmod; do
-  ln -sfv ../bin/kmod /usr/sbin/$target
-  rm -fv /usr/bin/$target
-done</userinput></screen>
+<screen><userinput remap="install">ninja install</userinput></screen>
 
   </sect2>
 

--- a/chapter08/sysklogd.xml
+++ b/chapter08/sysklogd.xml
@@ -47,6 +47,7 @@
             --sysconfdir=/etc  \
             --runstatedir=/run \
             --without-logger   \
+            --disable-static   \
             --docdir=/usr/share/doc/sysklogd-&sysklogd-version;</userinput></screen>
 
     <para>Kompiler pakken:</para>

--- a/packages.ent
+++ b/packages.ent
@@ -200,10 +200,10 @@
 <!ENTITY flex-fin-du "33 MB">
 <!ENTITY flex-fin-sbu "0.1 SBU">
 
-<!ENTITY flit-core-version "3.10.1">
-<!ENTITY flit-core-size "42 KB">
+<!ENTITY flit-core-version "3.11.0">
+<!ENTITY flit-core-size "51 KB">
 <!ENTITY flit-core-url "&pypi-src;/f/flit-core/flit_core-&flit-core-version;.tar.gz">
-<!ENTITY flit-core-md5 "a3381dd58e23e9826c5199b1f70318b0">
+<!ENTITY flit-core-md5 "6d677b1acef1769c4c7156c7508e0dbd">
 <!ENTITY flit-core-home "&pypi-home;/flit-core/">
 <!ENTITY flit-core-fin-du "1.0 MB">
 <!ENTITY flit-core-fin-sbu "less than 0.1 SBU">
@@ -245,10 +245,10 @@
 <!ENTITY gdbm-fin-du "13 MB">
 <!ENTITY gdbm-fin-sbu "less than 0.1 SBU">
 
-<!ENTITY gettext-version "0.23.1">
-<!ENTITY gettext-size "10,780 KB">
+<!ENTITY gettext-version "0.24">
+<!ENTITY gettext-size "8,120 KB">
 <!ENTITY gettext-url "&gnu;gettext/gettext-&gettext-version;.tar.xz">
-<!ENTITY gettext-md5 "1a174902c396e95c7d9761033fe1360e">
+<!ENTITY gettext-md5 "87aea3013802a3c60fa3feb5c7164069">
 <!ENTITY gettext-home "&gnu-software;gettext/">
 <!ENTITY gettext-tmp-du "349 MB">
 <!ENTITY gettext-tmp-sbu "1.3 SBU">
@@ -325,10 +325,10 @@
 <!ENTITY iana-etc-fin-du "4.8 MB">
 <!ENTITY iana-etc-fin-sbu "less than 0.1 SBU">
 
-<!ENTITY inetutils-version "2.5">
-<!ENTITY inetutils-size "1,632 KB">
+<!ENTITY inetutils-version "2.6">
+<!ENTITY inetutils-size "1,724 KB">
 <!ENTITY inetutils-url "&gnu;inetutils/inetutils-&inetutils-version;.tar.xz">
-<!ENTITY inetutils-md5 "9e5a6dfd2d794dc056a770e8ad4a9263">
+<!ENTITY inetutils-md5 "401d7d07682a193960bcdecafd03de94">
 <!ENTITY inetutils-home "&gnu-software;inetutils/">
 <!ENTITY inetutils-fin-du "35 MB">
 <!ENTITY inetutils-fin-sbu "0.2 SBU">
@@ -365,10 +365,10 @@
 <!ENTITY kbd-fin-du "34 MB">
 <!ENTITY kbd-fin-sbu "0.1 SBU">
 
-<!ENTITY kmod-version "33">
-<!ENTITY kmod-size "503 KB">
+<!ENTITY kmod-version "34">
+<!ENTITY kmod-size "331 KB">
 <!ENTITY kmod-url "&kernel;linux/utils/kernel/kmod/kmod-&kmod-version;.tar.xz">
-<!ENTITY kmod-md5 "c451c4aa61521adbe8af147f498046f8">
+<!ENTITY kmod-md5 "3e6c5c9ad9c7367ab9c3cc4f08dfde62">
 <!ENTITY kmod-home "https://github.com/kmod-project/kmod">
 <!ENTITY kmod-fin-du "11 MB">
 <!ENTITY kmod-fin-sbu "less than 0.1 SBU">
@@ -431,12 +431,12 @@
 
 <!ENTITY linux-major-version "6">
 <!ENTITY linux-minor-version "13">
-<!ENTITY linux-patch-version "2">
+<!ENTITY linux-patch-version "4">
 <!--<!ENTITY linux-version "&linux-major-version;.&linux-minor-version;">-->
 <!ENTITY linux-version "&linux-major-version;.&linux-minor-version;.&linux-patch-version;">
-<!ENTITY linux-size "145,012 KB">
+<!ENTITY linux-size "145,015 KB">
 <!ENTITY linux-url "&kernel;linux/kernel/v&linux-major-version;.x/linux-&linux-version;.tar.xz">
-<!ENTITY linux-md5 "437f6b439649d8c4c0dd03fda817f443">
+<!ENTITY linux-md5 "13b9e6c29105a34db4647190a43d1810">
 <!ENTITY linux-home "https://www.kernel.org/">
 <!-- measured for 6.10.1 / gcc-14.1.0 on x86_64 with -j4 : 
  minimum is allnoconfig 
@@ -637,18 +637,18 @@
 <!ENTITY sed-fin-du "30 MB">
 <!ENTITY sed-fin-sbu "0.3 SBU">
 
-<!ENTITY setuptools-version "75.8.0">
-<!ENTITY setuptools-size "1,312 KB">
+<!ENTITY setuptools-version "75.8.1">
+<!ENTITY setuptools-size "1,313 KB">
 <!ENTITY setuptools-url "&pypi-src;/s/setuptools/setuptools-&setuptools-version;.tar.gz">
-<!ENTITY setuptools-md5 "a42b075e3e18e724580f4caf7944354a">
+<!ENTITY setuptools-md5 "7dc3d3f529b76b10e35326e25c676b30">
 <!ENTITY setuptools-home "&pypi-home;/setuptools/">
 <!ENTITY setuptools-fin-du "26 MB">
 <!ENTITY setuptools-fin-sbu "less than 0.1 SBU">
 
-<!ENTITY shadow-version "4.17.2">
-<!ENTITY shadow-size "2,267 KB">
+<!ENTITY shadow-version "4.17.3">
+<!ENTITY shadow-size "2,274 KB">
 <!ENTITY shadow-url "&github;/shadow-maint/shadow/releases/download/&shadow-version;/shadow-&shadow-version;.tar.xz">
-<!ENTITY shadow-md5 "d9b6b8028ebb5971857b7f6b10ffba0e">
+<!ENTITY shadow-md5 "0da190e53ecee76237e4c8f3f39531ed">
 <!ENTITY shadow-home "&github;/shadow-maint/shadow/">
 <!ENTITY shadow-fin-du "114 MB">
 <!ENTITY shadow-fin-sbu "0.1 SBU">
@@ -661,21 +661,21 @@
 <!ENTITY sysklogd-fin-du "4.1 MB">
 <!ENTITY sysklogd-fin-sbu "less than 0.1 SBU">
 
-<!ENTITY systemd-version  "257">
+<!ENTITY systemd-version  "257.3">
 <!--<!ENTITY systemd-stable   "6b4878d">-->
 <!-- The above entity is used whenever we move to a stable backport branch. 
      In the event of a critical problem or kernel change that is incompatible, 
      we will switch to the backport branch until the next stable release. -->
-<!ENTITY systemd-size     "15,805 KB">
+<!ENTITY systemd-size     "15,847 KB">
 <!ENTITY systemd-url      "&github;/systemd/systemd/archive/v&systemd-version;/systemd-&systemd-version;.tar.gz">
 <!--<!ENTITY systemd-url      "&anduin-sources;/systemd-&systemd-version;-&systemd-stable;.tar.xz">-->
-<!ENTITY systemd-md5      "a51c7f9ab0d8b0a08dcf14bea2b6a5cb">
+<!ENTITY systemd-md5      "8e4fc90c7aead651fa5c50bd1b34abc2">
 <!ENTITY systemd-home     "https://www.freedesktop.org/wiki/Software/systemd/">
-<!ENTITY systemd-man-version "257">
-<!ENTITY systemd-man-size "732 KB">
+<!ENTITY systemd-man-version "257.3">
+<!ENTITY systemd-man-size "733 KB">
 <!--<!ENTITY systemd-man-url  "&anduin-sources;/systemd-man-pages-&systemd-version;-&systemd-stable;.tar.xz">-->
 <!ENTITY systemd-man-url  "&anduin-sources;/systemd-man-pages-&systemd-man-version;.tar.xz">
-<!ENTITY systemd-man-md5  "ac0b54961b1f20474fdff0927bc8be14">
+<!ENTITY systemd-man-md5  "9b77c3b066723d490cb10aed4fb05696">
 <!ENTITY systemd-fin-du   "307 MB">
 <!ENTITY systemd-fin-sbu  "1.1 SBU">
 
@@ -804,10 +804,10 @@
 <!ENTITY zlib-fin-du "6.4 MB">
 <!ENTITY zlib-fin-sbu "less than 0.1 SBU">
 
-<!ENTITY zstd-version "1.5.6">
-<!ENTITY zstd-size "2,351 KB">
+<!ENTITY zstd-version "1.5.7">
+<!ENTITY zstd-size "2,378 KB">
 <!ENTITY zstd-url "https://github.com/facebook/zstd/releases/download/v&zstd-version;/zstd-&zstd-version;.tar.gz">
-<!ENTITY zstd-md5 "5a473726b3445d0e5d6296afd1ab6854">
+<!ENTITY zstd-md5 "780fc1896922b1bc52a4e90980cdda48">
 <!ENTITY zstd-home "https://facebook.github.io/zstd/">
 <!ENTITY zstd-fin-du "85 MB">
 <!ENTITY zstd-fin-sbu "0.4 SBU">


### PR DESCRIPTION
Oppdatering til zstd-1.5.7.
Oppdatering til systemd-257.3.
Oppdater til shadow-4.17.3.
Oppdatering til setuptools-75.8.1.
Oppdatering til linux-6.13.4.
Oppdatering til kmod-34.
Oppdatering til inetutils-2.6.
Oppdatering til gettext-0.24.
Oppdatering til flit_core-3.11.0.

Fjern $LFS/{bin,lib,sbin} fra chown-kommandoene
 Dette gjelder avsnitt 4.3. Legge til LFS-brukeren'

Fjern statisk bibliotek i sysklogd
 Oppnådd med å legge til --disable-static til konfigureringsalternativene.