### PR TITLE
stylesheets: fiks generering av fotnoter

### DIFF
--- a/stylesheets/lfs-xsl/chunk-master.xsl
+++ b/stylesheets/lfs-xsl/chunk-master.xsl
@@ -27,8 +27,12 @@
          Prevent creation of dummy sect1 files used to emulate sub-chapters.
          The original template is in {docbook-xsl}/xhtml/chunk-code.xsl
          It also matches other sect* tags. The code for those tags are
-         unchanged. -->
-  <xsl:template match="sect1">
+         unchanged. Note that the priority attribute is not strictly
+         required, because the original template is less restrictive in
+         matching, so has less precedence. But in case the docbook dev
+         add a match="sect1" template in their chunk-code.xsl, then it will
+         be necessary!-->
+  <xsl:template match="sect1" priority="1">
     <xsl:variable name="ischunk">
       <xsl:call-template name="chunk"/>
     </xsl:variable>

--- a/stylesheets/lfs-xsl/xhtml/lfs-mixed.xsl
+++ b/stylesheets/lfs-xsl/xhtml/lfs-mixed.xsl
@@ -43,6 +43,16 @@
     </xsl:choose>
   </xsl:template>
 
+  <!-- footnote/para[1]: this template is in {docbook-xsl}/xhtml/footnote.xsl
+       which is imported. This means that template has less precedence
+       than the above one. To have higher precedence, it must be at
+       the same import level (then, since it is more restrictive, it is
+       applied preferably to the above).-->
+  <xsl:template match="footnote/para[1]">
+  <!-- just use the original template -->
+    <xsl:apply-imports/>
+  </xsl:template>
+
     <!-- screen:
            Changed class attribute asignament to fit our look needs.
            Removed unused line numbering support. -->

--- a/stylesheets/lfs-xsl/xhtml/lfs-sections.xsl
+++ b/stylesheets/lfs-xsl/xhtml/lfs-sections.xsl
@@ -166,7 +166,7 @@
       </xsl:choose>
       <xsl:call-template name="language.attribute"/>
       <xsl:apply-templates/>
-      <xsl:apply-templates select="sect1info" mode="svn-keys"/>
+      <xsl:call-template name="process.footnotes"/>
     </div>
   </xsl:template>
 


### PR DESCRIPTION
Det var to problemer:
- sect1-malen behandlet ikke fotnoten
- Fotnotebehandling er nødvendig for å bruke en malmatching fotnote/para[1], men vi hadde en mal som matcher para på et høyere presensnivå. Så:
- ring process.footnotes på slutten av sect1-malen
- Legg til en mal som matcher fotnote/para[1] ved samme import nivå som malens matchende paragraf (dette kaller bare originalen mal) Vi legger også til en prioritet 1 til sect1-malen i chunk-code.xsl, selv om det ikke er strengt nødvendig. Dette er hva oppstrøms anbefaler...