### PR TITLE
Pakkeoppdateringer.

### DIFF
--- a/chapter01/changelog.xml
+++ b/chapter01/changelog.xml
@@ -39,7 +39,63 @@
     <listitem revision="sysv"> or <listitem revision="systemd"> as
     appropriate for the entry or if needed the entire day's listitem.
     -->
-
+    <listitem>
+      <para>2025-04-01</para>
+      <itemizedlist>
+        <listitem>
+          <para>[bdubbs] - Oppdater til vim-9.1.1263. Adresserer
+          <ulink url='&lfs-ticket-root;4500'>#4500</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdater til iana-etc-20250328. Adresserer
+          <ulink url='&lfs-ticket-root;5006'>#5006</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdater til xz-5.8.0. Fikser
+          <ulink url='&lfs-ticket-root;5684'>#5684</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdater til util-linux-2.41. Fikser
+          <ulink url='&lfs-ticket-root;5648'>#5648</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdater til tzdata-2025b. Fikser
+          <ulink url='&lfs-ticket-root;5681'>#5681</ulink>.</para>
+        </listitem>
+        <listitem revision='sysv'>
+          <para>[bdubbs] - Oppdater til shadow-4.17.4. Fikser
+          <ulink url='&lfs-ticket-root;5678'>#5678</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdater til setuptools-78.1.0. Fikser
+          <ulink url='&lfs-ticket-root;5676'>#5676</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdater til patch-2.8. Fikser
+          <ulink url='&lfs-ticket-root;5689'>#5689</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdater til mpfr-4.2.2. Fikser
+          <ulink url='&lfs-ticket-root;5677'>#5677</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdater til kmod-34.2. Fikser
+          <ulink url='&lfs-ticket-root;5688'>#5688</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdater til gdbm-1.25. Fikser
+          <ulink url='&lfs-ticket-root;5679'>#5679</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdater til flit_core-3.12.0. Fikser
+          <ulink url='&lfs-ticket-root;5683'>#5683</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdater til expat-2.7.1. Fikser
+          <ulink url='&lfs-ticket-root;5685'>#5685</ulink>.</para>
+        </listitem>
+      </itemizedlist>
+    </listitem>
     <listitem>
       <para>15.03.2025</para>
       <itemizedlist>

--- a/chapter01/whatsnew.xml
+++ b/chapter01/whatsnew.xml
@@ -86,18 +86,18 @@
     <!--<listitem>
       <para>Flex-&flex-version;</para>
     </listitem>-->
-    <!--<listitem>
+    <listitem>
       <para>Flit-core-&flit-core-version;</para>
-    </listitem>-->
+    </listitem>
     <!--<listitem>
       <para>Gawk-&gawk-version;</para>
     </listitem>-->
     <!--<listitem>
        <para>GCC-&gcc-version;</para>
     </listitem>-->
-    <!--<listitem>
+    <listitem>
        <para>GDBM-&gdbm-version;</para>
-    </listitem>-->
+    </listitem>
     <!--<listitem>
       <para>Gettext-&gettext-version;</para>
     </listitem>-->
@@ -194,9 +194,9 @@
     <!--<listitem>
       <para>MPC-&mpc-version;</para>
     </listitem>-->
-    <!--<listitem>
+    <listitem>
       <para>MPFR-&mpfr-version;</para>
-    </listitem>-->
+    </listitem>
     <!--<listitem>
       <para>Ncurses-&ncurses-version;</para>
     </listitem>-->
@@ -206,9 +206,9 @@
     <!--<listitem>
       <para>OpenSSL-&openssl-version;</para>
     </listitem>-->
-    <!--<listitem>
+    <listitem>
       <para>Patch-&patch-version;</para>
-    </listitem>-->
+    </listitem>
     <!--<listitem>
       <para>Perl-&perl-version;</para>
     </listitem>-->
@@ -233,9 +233,9 @@
     <listitem>
       <para>Setuptools-&setuptools-version;</para>
     </listitem>
-    <!--<listitem>
+    <listitem>
       <para>Shadow-&shadow-version;</para>
-    </listitem>-->
+    </listitem>
     <listitem revision="sysv">
       <para>Sysklogd-&sysklogd-version;</para>
     </listitem>
@@ -254,15 +254,15 @@
     <!--<listitem>
       <para>Texinfo-&texinfo-version;</para>
     </listitem>-->
-    <!--<listitem>
+    <listitem>
       <para>Tzdata-&tzdata-version;</para>
-    </listitem>-->
+    </listitem>
     <!--<listitem revision="sysv">
       <para>Udev from Systemd-&systemd-version;</para>
     </listitem>-->
-    <!--<listitem>
+    <listitem>
       <para>Util-linux-&util-linux-version;</para>
-    </listitem>-->
+    </listitem>
     <listitem>
       <para>Vim-&vim-version;</para>
     </listitem>
@@ -272,9 +272,9 @@
     <!--<listitem>
       <para>XML::Parser-&xml-parser-version;</para>
     </listitem>-->
-    <!--<listitem>
+    <listitem>
       <para>Xz-&xz-version;</para>
-    </listitem>-->
+    </listitem>
     <!--<listitem>
       <para>Zlib-&zlib-version;</para>
     </listitem>-->

--- a/chapter08/gcc.xml
+++ b/chapter08/gcc.xml
@@ -223,7 +223,7 @@ su tester -c "PATH=$PATH make -k check"</userinput></screen>
     at kompilering og kobling vil fungere som forventet. Dette gjør vi ved å utføre
     noen sunnhetssjekker:</para>
 
-<screen><userinput>echo 'int main(){}' | cc dummy.c -x c - -v -Wl,--verbose &amp;&gt; dummy.log
+<screen><userinput>echo 'int main(){}' | cc -x c - -v -Wl,--verbose &amp;&gt; dummy.log
 readelf -l a.out | grep ': /lib'</userinput></screen>
 
   <para>Det bør ikke være noen feil,

--- a/packages.ent
+++ b/packages.ent
@@ -61,7 +61,7 @@
 <!ENTITY bc-size "464 KB">
 <!ENTITY bc-url "https://github.com/gavinhoward/bc/releases/download/&bc-version;/bc-&bc-version;.tar.xz">
 <!ENTITY bc-md5 "ad4db5a0eb4fdbb3f6813be4b6b3da74">
-<!ENTITY bc-home "https://git.gavinhoward.com/gavin/bc">
+<!ENTITY bc-home "https://github.com/gavinhoward">
 <!ENTITY bc-fin-du "7.8 MB">
 <!ENTITY bc-fin-sbu "less than 0.1 SBU">
 
@@ -156,10 +156,10 @@
 <!ENTITY elfutils-fin-du "135 MB">
 <!ENTITY elfutils-fin-sbu "0.3 SBU">
 
-<!ENTITY expat-version "2.7.0">
-<!ENTITY expat-size "482 KB">
+<!ENTITY expat-version "2.7.1">
+<!ENTITY expat-size "485 KB">
 <!ENTITY expat-url "&sourceforge;expat/expat-&expat-version;.tar.xz">
-<!ENTITY expat-md5 "974e9de880e731c00112ca069062343a">
+<!ENTITY expat-md5 "9f0c266ff4b9720beae0c6bd53ae4469">
 <!ENTITY expat-home "https://libexpat.github.io/">
 <!ENTITY expat-fin-du "14 MB">
 <!ENTITY expat-fin-sbu "0.1 SBU">
@@ -200,10 +200,10 @@
 <!ENTITY flex-fin-du "33 MB">
 <!ENTITY flex-fin-sbu "0.1 SBU">
 
-<!ENTITY flit-core-version "3.11.0">
-<!ENTITY flit-core-size "51 KB">
+<!ENTITY flit-core-version "3.12.0">
+<!ENTITY flit-core-size "53 KB">
 <!ENTITY flit-core-url "&pypi-src;/f/flit-core/flit_core-&flit-core-version;.tar.gz">
-<!ENTITY flit-core-md5 "6d677b1acef1769c4c7156c7508e0dbd">
+<!ENTITY flit-core-md5 "c538415c1f27bd69cbbbf3cdd5135d39">
 <!ENTITY flit-core-home "&pypi-home;/flit-core/">
 <!ENTITY flit-core-fin-du "1.0 MB">
 <!ENTITY flit-core-fin-sbu "less than 0.1 SBU">
@@ -237,10 +237,10 @@
 <!ENTITY libstdcpp-tmpp1-du "850 MB">
 <!ENTITY libstdcpp-tmpp1-sbu "0.2 SBU">
 
-<!ENTITY gdbm-version "1.24">
-<!ENTITY gdbm-size "1,168 KB">
+<!ENTITY gdbm-version "1.25">
+<!ENTITY gdbm-size "1,196 KB">
 <!ENTITY gdbm-url "&gnu;gdbm/gdbm-&gdbm-version;.tar.gz">
-<!ENTITY gdbm-md5 "c780815649e52317be48331c1773e987">
+<!ENTITY gdbm-md5 "46266720c7980b75f29e3554aeaeb7a8">
 <!ENTITY gdbm-home "&gnu-software;gdbm/">
 <!ENTITY gdbm-fin-du "13 MB">
 <!ENTITY gdbm-fin-sbu "less than 0.1 SBU">
@@ -317,10 +317,10 @@
 <!ENTITY gzip-fin-du "21 MB">
 <!ENTITY gzip-fin-sbu "0.3 SBU">
 
-<!ENTITY iana-etc-version "20250304">
-<!ENTITY iana-etc-size "591 KB">
+<!ENTITY iana-etc-version "20250328">
+<!ENTITY iana-etc-size "592 KB">
 <!ENTITY iana-etc-url "https://github.com/Mic92/iana-etc/releases/download/&iana-etc-version;/iana-etc-&iana-etc-version;.tar.gz">
-<!ENTITY iana-etc-md5 "e01a3d742ad61738879fd5d461dd5c50">
+<!ENTITY iana-etc-md5 "c1ac238c282feee8e4f4e44a7e490615">
 <!ENTITY iana-etc-home "https://www.iana.org/protocols">
 <!ENTITY iana-etc-fin-du "4.8 MB">
 <!ENTITY iana-etc-fin-sbu "less than 0.1 SBU">
@@ -365,10 +365,10 @@
 <!ENTITY kbd-fin-du "34 MB">
 <!ENTITY kbd-fin-sbu "0.1 SBU">
 
-<!ENTITY kmod-version "34.1">
-<!ENTITY kmod-size "331 KB">
+<!ENTITY kmod-version "34.2">
+<!ENTITY kmod-size "434 KB">
 <!ENTITY kmod-url "&kernel;linux/utils/kernel/kmod/kmod-&kmod-version;.tar.xz">
-<!ENTITY kmod-md5 "bdc01ba7d330685af597c16c5f58c0e2">
+<!ENTITY kmod-md5 "36f2cc483745e81ede3406fa55e1065a">
 <!ENTITY kmod-home "https://github.com/kmod-project/kmod">
 <!ENTITY kmod-fin-du "11 MB">
 <!ENTITY kmod-fin-sbu "less than 0.1 SBU">
@@ -519,10 +519,10 @@
 <!ENTITY mpc-fin-du "22 MB">
 <!ENTITY mpc-fin-sbu "0.1 SBU">
 
-<!ENTITY mpfr-version "4.2.1">
-<!ENTITY mpfr-size "1,459 KB">
+<!ENTITY mpfr-version "4.2.2">
+<!ENTITY mpfr-size "1,471 KB">
 <!ENTITY mpfr-url "https://ftp.gnu.org/gnu/mpfr/mpfr-&mpfr-version;.tar.xz">
-<!ENTITY mpfr-md5 "523c50c6318dde6f9dc523bc0244690a">
+<!ENTITY mpfr-md5 "7c32c39b8b6e3ae85f25156228156061">
 <!ENTITY mpfr-home "https://www.mpfr.org/">
 <!ENTITY mpfr-fin-du "43 MB">
 <!ENTITY mpfr-fin-sbu "0.2 SBU">
@@ -553,10 +553,10 @@
 <!ENTITY openssl-fin-du "920 MB">
 <!ENTITY openssl-fin-sbu "1.8 SBU">
 
-<!ENTITY patch-version "2.7.6">
-<!ENTITY patch-size "766 KB">
+<!ENTITY patch-version "2.8">
+<!ENTITY patch-size "886 KB">
 <!ENTITY patch-url "&gnu;patch/patch-&patch-version;.tar.xz">
-<!ENTITY patch-md5 "78ad9937e4caadcba1526ef1853730d5">
+<!ENTITY patch-md5 "149327a021d41c8f88d034eab41c039f">
 <!ENTITY patch-home "https://savannah.gnu.org/projects/patch/">
 <!ENTITY patch-tmp-du "12 MB">
 <!ENTITY patch-tmp-sbu "0.1 SBU">
@@ -637,18 +637,18 @@
 <!ENTITY sed-fin-du "30 MB">
 <!ENTITY sed-fin-sbu "0.3 SBU">
 
-<!ENTITY setuptools-version "76.0.0">
-<!ENTITY setuptools-size "1,318 KB">
+<!ENTITY setuptools-version "78.1.0">
+<!ENTITY setuptools-size "1,336 KB">
 <!ENTITY setuptools-url "&pypi-src;/s/setuptools/setuptools-&setuptools-version;.tar.gz">
-<!ENTITY setuptools-md5 "a15701d19326a1d4132fce56f2861a60">
+<!ENTITY setuptools-md5 "c20bf3068cdb26629854bec1ba8d2374">
 <!ENTITY setuptools-home "&pypi-home;/setuptools/">
 <!ENTITY setuptools-fin-du "26 MB">
 <!ENTITY setuptools-fin-sbu "less than 0.1 SBU">
 
-<!ENTITY shadow-version "4.17.3">
-<!ENTITY shadow-size "2,274 KB">
+<!ENTITY shadow-version "4.17.4">
+<!ENTITY shadow-size "2,273 KB">
 <!ENTITY shadow-url "&github;/shadow-maint/shadow/releases/download/&shadow-version;/shadow-&shadow-version;.tar.xz">
-<!ENTITY shadow-md5 "0da190e53ecee76237e4c8f3f39531ed">
+<!ENTITY shadow-md5 "469666ea82c203ce5b0116d26b3793a9">
 <!ENTITY shadow-home "&github;/shadow-maint/shadow/">
 <!ENTITY shadow-fin-du "114 MB">
 <!ENTITY shadow-fin-sbu "0.1 SBU">
@@ -719,10 +719,10 @@
 <!ENTITY texinfo-fin-du "160 MB">
 <!ENTITY texinfo-fin-sbu "0.3 SBU">
 
-<!ENTITY tzdata-version "2025a">
-<!ENTITY tzdata-size "453 KB">
+<!ENTITY tzdata-version "2025b">
+<!ENTITY tzdata-size "454 KB">
 <!ENTITY tzdata-url "https://www.iana.org/time-zones/repository/releases/tzdata&tzdata-version;.tar.gz">
-<!ENTITY tzdata-md5 "404229390c06b7440f5e48d12c1a3251">
+<!ENTITY tzdata-md5 "ad65154c48c74a9b311fe84778c5434f">
 <!ENTITY tzdata-home "https://www.iana.org/time-zones">
 
 <!ENTITY udev-lfs-version "udev-lfs-20230818">
@@ -733,21 +733,21 @@
 <!ENTITY udev-fin-du "161 MB">
 <!ENTITY udev-fin-sbu "0.3 SBU">
 
-<!ENTITY util-linux-minor "2.40">
-<!ENTITY util-linux-version "2.40.4"> <!-- 2.33.x -->
-<!ENTITY util-linux-size "8,641 KB">
+<!ENTITY util-linux-minor "2.41">
+<!ENTITY util-linux-version "2.41"> <!-- 2.33.x -->
+<!ENTITY util-linux-size "9,313 KB">
 <!ENTITY util-linux-url "&kernel;linux/utils/util-linux/v&util-linux-minor;/util-linux-&util-linux-version;.tar.xz">
-<!ENTITY util-linux-md5 "f9cbb1c8315d8ccbeb0ec36d10350304">
+<!ENTITY util-linux-md5 "e666a34b03554c18a1073347b16661ce">
 <!ENTITY util-linux-home "https://git.kernel.org/pub/scm/utils/util-linux/util-linux.git/">
 <!ENTITY util-linux-tmp-du "182 MB">
 <!ENTITY util-linux-tmp-sbu "0.2 SBU">
 <!ENTITY util-linux-fin-du "316 MB">
 <!ENTITY util-linux-fin-sbu "0.5 SBU">
 
-<!ENTITY vim-version "9.1.1202">
+<!ENTITY vim-version "9.1.1263">
 <!-- <!ENTITY vim-majmin "90"> -->
 <!ENTITY vim-docdir "vim/vim91">
-<!ENTITY vim-size "18,114 KB">
+<!ENTITY vim-size "18,260 KB">
 <!ENTITY vim-url "https://github.com/vim/vim/archive/v&vim-version;/vim-&vim-version;.tar.gz">
 <!-- N.B. LFS 9.0 uses
      https://github.com/vim/vim/archive/v8.1.1846/vim-8.1.1846.tar.gz
@@ -761,7 +761,7 @@
      example, https://github.com/vim/vim/tags?after=v8.1.1847 will show
      us v8.1.1846. -->
 <!--<!ENTITY vim-url "&anduin-sources;/vim-&vim-version;.tar.gz">-->
-<!ENTITY vim-md5 "97d30bee45129ac75b95dd0ade5c10e0">
+<!ENTITY vim-md5 "75b86835e6e55910f4c14502f7ce0bc4">
 <!ENTITY vim-home "https://www.vim.org">
 <!ENTITY vim-fin-du "251 MB">
 <!ENTITY vim-fin-sbu "3.4 SBU">
@@ -782,10 +782,10 @@
 <!ENTITY xml-parser-fin-du "2.4 MB">
 <!ENTITY xml-parser-fin-sbu "less than 0.1 SBU">
 
-<!ENTITY xz-version "5.6.4">
-<!ENTITY xz-size "1,310 KB">
+<!ENTITY xz-version "5.8.0">
+<!ENTITY xz-size "1,424 KB">
 <!ENTITY xz-url "https://github.com//tukaani-project/xz/releases/download/v&xz-version;/xz-&xz-version;.tar.xz">
-<!ENTITY xz-md5 "4b1cf07d45ec7eb90a01dd3c00311a3e">
+<!ENTITY xz-md5 "3bfff9c10abc3b7fb25962be8b0359fb">
 <!ENTITY xz-home "https://tukaani.org/xz">
 <!ENTITY xz-tmp-du "21 MB">
 <!ENTITY xz-tmp-sbu "0.1 SBU">


### PR DESCRIPTION
Oppdatering til vim-9.1.1263.
Oppdatering til iana-etc-20250328.
Oppdatering til xz-5.8.0.
Oppdatering til util-linux-2.41.
Oppdatering til tzdata-2025b.
Oppdater til shadow-4.17.4.
Oppdatering til setuptools-78.1.0.
Oppdatering til patch-2.8.
Oppdatering til mpfr-4.2.2.
Oppdatering til kmod-34.2.
Oppdatering til gdbm-1.25.
Oppdatering til flit_core-3.12.0.
Oppdatering til expat-3.7.1.