### PR TITLE
Endre stripping til å bruke --strip-debug

### DIFF
--- a/chapter08/stripping.xml
+++ b/chapter08/stripping.xml
@@ -24,10 +24,15 @@
   sikkerhetskopiering av LFS systemet i gjeldende tilstand.</para>
 
   <para>En <command>strip</command> kommando med
-  <parameter>--strip-unneeded</parameter> alternativet fjerner alle feilsøkingssymboler
-  fra en binær eller et bibliotek. Og det fjerner alle symboltabelloppføringer
-  som ikke er nødvendig for linkeren (for statiske biblioteker) eller dynamisk linker (for
-  dynamisk koblede binære filer og delte biblioteker).</para>
+  <parameter>--strip-unneeded</parameter> alternativet fjerner alle feilsøkingssymboler fra
+  en binær eller et bibliotek. Den fjerner også alle symboltabelloppføringer som ikke er normalt
+  og ikke er nødvendig for linkeren (for statiske biblioteker) eller dynamisk linker (for
+  dynamisk koblede binærfiler og delte biblioteker). Å bruke
+  <parameter>--strip-debug</parameter> fjerner ikke symboltabelloppføringer
+  som kan være nødvendig for noen applikasjoner. Forskjellen mellom "unneeded"
+  og "debug" er veldig liten. For eksempel er en unstrippet libc.a 22,4 MB.
+  Etter stripping med --strip-debug er den 5,9 MB. Bruker kun --strip-uneeded
+  reduserer størrelsen ytterligere til bare 5,8 MB.</para>
 
   <!-- TODO: Zstd is better than Zlib for both speed and size.
              Unfortunately Valgrind does not support Zstd-compressed debug
@@ -83,7 +88,7 @@ cd /usr/lib
 for LIB in $save_usrlib; do
     objcopy --only-keep-debug $LIB $LIB.dbg
     cp $LIB /tmp/$LIB
-    strip --strip-unneeded /tmp/$LIB
+    strip --strip-debug /tmp/$LIB
     objcopy --add-gnu-debuglink=$LIB.dbg /tmp/$LIB
     install -vm755 /tmp/$LIB /usr/lib
     rm /tmp/$LIB
@@ -102,14 +107,14 @@ online_usrlib="libbfd-&binutils-version;.so
 
 for BIN in $online_usrbin; do
     cp /usr/bin/$BIN /tmp/$BIN
-    strip --strip-unneeded /tmp/$BIN
+    strip --strip-debug /tmp/$BIN
     install -vm755 /tmp/$BIN /usr/bin
     rm /tmp/$BIN
 done
 
 for LIB in $online_usrlib; do
     cp /usr/lib/$LIB /tmp/$LIB
-    strip --strip-unneeded /tmp/$LIB
+    strip --strip-debug /tmp/$LIB
     install -vm755 /tmp/$LIB /usr/lib
     rm /tmp/$LIB
 done
@@ -120,7 +125,7 @@ for i in $(find /usr/lib -type f -name \*.so* ! -name \*dbg) \
     case "$online_usrbin $online_usrlib $save_usrlib" in
         *$(basename $i)* )
             ;;
-        * ) strip --strip-unneeded $i
+        * ) strip --strip-debug $i
             ;;
     esac
 done


### PR DESCRIPTION
Når vi bruker -strip-uneeded fjerner det noen symboler som er nødvendige i statisk biblioteker som kan være nødvendig i tillegg til feilsøking av symboler. Endring av stripping til det mer konservative --strip-debug beholder disse symbolene.

I tilfellet med libc.a er den ikke-strippede filstørrelsen 22,4 MB. Bruker --strip-debug reduserer filstørrelsen med 74 prosent til 5,9 MB.

Bruk av --strip-unneeded reduserer bare filen ytterligere med 89 KB, så enhver gevinst er relativt triviell.