### PR TITLE
python: Legg også til --without-static-libpython i den midlertidige i…

### DIFF
--- a/chapter07/python.xml
+++ b/chapter07/python.xml
@@ -52,9 +52,10 @@
 
     <para>Forbered Python for kompilering:</para>
 
-<screen><userinput remap="configure">./configure --prefix=/usr   \
-            --enable-shared \
-            --without-ensurepip</userinput></screen>
+<screen><userinput remap="configure">./configure --prefix=/usr       \
+            --enable-shared     \
+            --without-ensurepip \
+            --without-static-libpython</userinput></screen>
 
     <variablelist>
       <title>Betydningen av konfigureringsalternativet:</title>
@@ -74,6 +75,13 @@
         </listitem>
       </varlistentry>
 
+      <varlistentry>
+        <term><parameter>--without-static-libpython</parameter></term>
+        <listitem>
+          <para>Denne bryteren forhindrer bygging av et stort, men unødvendig, statisk
+		  bibliotek.</para>
+        </listitem>
+      </varlistentry>
     </variablelist>
 
     <para>Kompiler pakken:</para>

--- a/chapter08/python.xml
+++ b/chapter08/python.xml
@@ -77,14 +77,6 @@
       </listitem>
     </varlistentry>
 
-    <varlistentry>
-      <term><parameter>--without-static-libpython</parameter></term>
-      <listitem>
-        <para>Denne bryteren forhindrer bygging av et stort, men unødvendig, statisk
-		bibliotek.</para>
-      </listitem>
-    </varlistentry>
-
     </variablelist>
 
     <para>Kompiler pakken:</para>


### PR DESCRIPTION
…nstallasjonen

Uten den, i det endelige systemet er /usr/lib/python3.13/config-3.13-$triple/libpython3.13.a en rest fra kapittel 7 i stedet for å være fraværende, noe som motvirker vår vilje til å spare plass.