### PR TITLE
Rett «For mange nivåer av symbolske lenker» i kapittel 8 i ncurses

### DIFF
--- a/chapter06/ncurses.xml
+++ b/chapter06/ncurses.xml
@@ -44,13 +44,16 @@
     <title>Installasjon av Ncurses</title>
 
     <para>Først, kjør følgende kommandoer for å bygge <quote>tic</quote>
-    programmet på byggeverten:</para>
+      programmet på byggeverten. Vi installerer den i
+      <filename class="directory">$LFS/tools</filename>, slik at den blir funnet
+      i <envar>PATH</envar> ved behov:</para>
 
 <screen><userinput remap="pre">mkdir build
 pushd build
-  ../configure AWK=gawk
+  ../configure --prefix=$LFS/tools AWK=gawk
   make -C include
   make -C progs tic
+  install progs/tic $LFS/tools/bin
 popd</userinput></screen>
 
     <para>Forbered Ncurses for kompilering:</para>
@@ -139,7 +142,6 @@ popd</userinput></screen>
           is there any updated into? --></para>
         </listitem>
       </varlistentry>
-
     </variablelist>
 
     <para>Kompiler pakken:</para>
@@ -148,27 +150,13 @@ popd</userinput></screen>
 
     <para>Installer pakken:</para>
 
-<screen><userinput remap="install">make DESTDIR=$LFS TIC_PATH=$(pwd)/build/progs/tic install
+<screen><userinput remap="install">make DESTDIR=$LFS install
 ln -sv libncursesw.so $LFS/usr/lib/libncurses.so
 sed -e 's/^#if.*XOPEN.*$/#if 1/' \
     -i $LFS/usr/include/curses.h</userinput></screen>
-<!--
-    <para>Fjern et unødvendig statisk bibliotek som ikke håndteres av
-    <command>configure</command>:</para>
 
-<screen><userinput remap="install">rm -v $LFS/usr/lib/libncurses++w.a</userinput></screen>
--->
     <variablelist>
       <title>Betydningen av installasjonsalternativene:</title>
-
-      <varlistentry>
-        <term><parameter>TIC_PATH=$(pwd)/build/progs/tic</parameter></term>
-        <listitem>
-          <para>Vi må sende stien til den nettopp bygde
-          <command>tic</command> programmet som kjører på byggemaskinen, slik at
-          terminaldatabasen kan opprettes uten feil.</para>
-        </listitem>
-      </varlistentry>
 
       <varlistentry>
         <term><command>ln -sv libncursesw.so $LFS/usr/lib/libncurses.so</command></term>


### PR DESCRIPTION
Problemet er at TIC_PATH ikke lenger brukes i kapittel 6, slik at tic fra verten brukes til å opprette terminfo databasen i kapittel 6. Problemet er at gamle versjoner av tic lager symbolske lenker i databasen, mens nyere versjoner lager hardlinker. Siden vi bruker en DESTDIR-installasjon i kapittel 8 (med en nyere versjon av ncurses, altså med hardlinker), og kopierer den på plass med cp -a, ser det ut til at kopiering av hardlinker til symbolske lenker. Hvis en gammel versjon av tic har blitt brukt i kapittel 6, kopierer dette hardlinker til symbolske lenker, som lager symbolske lenker som peker til seg selv (cp-feil?).

Uansett, løsningen er å kopiere hjelpe tic-en som er innebygd i kapittel 6 til $LFS/tools/bin (forslag fra Xi Ruoyao). Nå er det ikke nødvendig å sette TIC_PATH eller hva som helst fordi denne tic-en er i PATH.

Feilen ble først rapportert av Marcin Dulak. Analyse med hjelp av Bruce Dubbs og Thomas Trepl.

Rettelser https://wiki.linuxfromscratch.org/lfs/ticket/5744