### PR TITLE
Pakkeoppdateringer.

### DIFF
--- a/chapter01/changelog.xml
+++ b/chapter01/changelog.xml
@@ -39,6 +39,45 @@
     <listitem revision="sysv"> or <listitem revision="systemd"> as
     appropriate for the entry or if needed the entire day's listitem.
     -->
+
+    <listitem>
+      <para>15.07.2025</para>
+      <itemizedlist>
+        <listitem>
+          <para>[bdubbs] - Oppdater til readline-8.3. Fikser
+          <ulink url='&lfs-ticket-root;5755'>#5755</ulink>.</para>
+        </listitem>
+        <listitem revision='sysv'>
+          <para>[bdubbs] - Oppdater til perl-5.42.0. Fikser
+          <ulink url='&lfs-ticket-root;5756'>#5756</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdater til openssl-3.5.1. Fikser
+          <ulink url='&lfs-ticket-root;5723'>#5723</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdater til ninja-1.13.1. Fikser
+          <ulink url='&lfs-ticket-root;5759'>#5759</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdater til linux-6.15.6. Fikser
+          <ulink url='&lfs-ticket-root;5757'>#5757</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdater til gettext-0.25.1. Fikser
+          <ulink url='&lfs-ticket-root;5753'>#5753</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdater til e2fsprogs-1.47.3. Fikser
+          <ulink url='&lfs-ticket-root;5758'>#5758</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdater til bash-5.3. Fikser
+          <ulink url='&lfs-ticket-root;5754'>#5754</ulink>.</para>
+        </listitem>
+      </itemizedlist>
+    </listitem>
+
     <listitem>
       <para>01.07.2025</para>
       <itemizedlist>

--- a/chapter01/whatsnew.xml
+++ b/chapter01/whatsnew.xml
@@ -65,9 +65,9 @@
     <listitem>
       <para>Diffutils-&diffutils-version;</para>
     </listitem>
-    <!--<listitem>
+    <listitem>
        <para>E2fsprogs-&e2fsprogs-version;</para>
-    </listitem>-->
+    </listitem>
     <listitem>
        <para>Expat-&expat-version;</para>
     </listitem>

--- a/chapter03/patches.xml
+++ b/chapter03/patches.xml
@@ -124,7 +124,6 @@
         <para>MD5 sum: <literal>&libpipeline-checks-patch-md5;</literal></para>
       </listitem>
     </varlistentry>
--->
 
     <varlistentry>
       <term>Perl Upstream Fix Patch - <token>&perl-upstream-fix-patch-size;</token>:</term>
@@ -134,7 +133,6 @@
       </listitem>
     </varlistentry>
 
-<!--
     <varlistentry>
       <term>Python Security Fix Patch - <token>&python-security-fixes-patch-size;</token>:</term>
       <listitem>

--- a/chapter08/perl.xml
+++ b/chapter08/perl.xml
@@ -40,11 +40,11 @@
 
   <sect2 role="installation">
     <title>Installasjon av Perl</title>
-
+<!--
     <para>Først må du bruke en sikkerhetsoppdatering som er identifisert oppstrøms:</para>
 
 <screen><userinput remap="pre">patch -Np1 -i ../&perl-upstream-fix-patch;</userinput></screen>
-
+-->
     <para>Denne versjonen av Perl bygger nå Compress::Raw::Zlib og
     Compress::Raw::BZip2 moduler. Som
     standard vil Perl bruke en intern kopi av kildene for å bygge.

--- a/packages.ent
+++ b/packages.ent
@@ -47,10 +47,10 @@
 <!ENTITY automake-fin-du "121 MB">
 <!ENTITY automake-fin-sbu "mindre enn 0.1 SBU (omtrent 1.1 SBU med tester)">
 
-<!ENTITY bash-version "5.3-rc2">
-<!ENTITY bash-size "10,774 KB">
+<!ENTITY bash-version "5.3">
+<!ENTITY bash-size "11,089 KB">
 <!ENTITY bash-url "&gnu;bash/bash-&bash-version;.tar.gz">
-<!ENTITY bash-md5 "9c440d7c5ca37433e496c5e22f8918c6">
+<!ENTITY bash-md5 "4c7fb7d82586f93ab1d833ef20378ee8">
 <!ENTITY bash-home "&gnu-software;bash/">
 <!ENTITY bash-tmp-du "68 MB">
 <!ENTITY bash-tmp-sbu "0.2 SBU">
@@ -132,10 +132,10 @@
 <!ENTITY diffutils-fin-du "50 MB">
 <!ENTITY diffutils-fin-sbu "0.4 SBU">
 
-<!ENTITY e2fsprogs-version "1.47.2">
-<!ENTITY e2fsprogs-size "9,763 KB">
+<!ENTITY e2fsprogs-version "1.47.3">
+<!ENTITY e2fsprogs-size "9,851 KB">
 <!ENTITY e2fsprogs-url "https://downloads.sourceforge.net/project/e2fsprogs/e2fsprogs/v&e2fsprogs-version;/e2fsprogs-&e2fsprogs-version;.tar.gz">
-<!ENTITY e2fsprogs-md5 "752e5a3ce19aea060d8a203f2fae9baa">
+<!ENTITY e2fsprogs-md5 "113d7a7ee0710d2a670a44692a35fd2e">
 <!ENTITY e2fsprogs-home "https://e2fsprogs.sourceforge.net/">
 <!ENTITY e2fsprogs-fin-du "99 MB">
 <!ENTITY e2fsprogs-fin-sbu "2.4 SBU på en roterende disk, 0.5 SBU på en SSD">
@@ -237,10 +237,10 @@
 <!ENTITY gdbm-fin-du "13 MB">
 <!ENTITY gdbm-fin-sbu "mindre enn 0.1 SBU">
 
-<!ENTITY gettext-version "0.25">
-<!ENTITY gettext-size "9,701 KB">
+<!ENTITY gettext-version "0.25.1">
+<!ENTITY gettext-size "9,699 KB">
 <!ENTITY gettext-url "&gnu;gettext/gettext-&gettext-version;.tar.xz">
-<!ENTITY gettext-md5 "355a09fa53ae2e87dd493e040d437874">
+<!ENTITY gettext-md5 "78fe5203bc80e9d916f9509026f07de9">
 <!ENTITY gettext-home "&gnu-software;gettext/">
 <!ENTITY gettext-tmp-du "349 MB">
 <!ENTITY gettext-tmp-sbu "1.3 SBU">
@@ -423,12 +423,12 @@
 
 <!ENTITY linux-major-version "6">
 <!ENTITY linux-minor-version "15">
-<!ENTITY linux-patch-version "4">
+<!ENTITY linux-patch-version "6">
 <!--<!ENTITY linux-version "&linux-major-version;.&linux-minor-version;">-->
 <!ENTITY linux-version "&linux-major-version;.&linux-minor-version;.&linux-patch-version;">
-<!ENTITY linux-size "147,682 KB">
+<!ENTITY linux-size "147,622 KB">
 <!ENTITY linux-url "&kernel;linux/kernel/v&linux-major-version;.x/linux-&linux-version;.tar.xz">
-<!ENTITY linux-md5 "bdbac42cc976b88514ad9083cfee7e0f">
+<!ENTITY linux-md5 "019a3cea6458f01331dfa5afdd1ce252">
 <!ENTITY linux-home "https://www.kernel.org/">
 <!-- measured for 6.10.1 / gcc-14.1.0 on x86_64 with -j4 : 
  minimum is allnoconfig 
@@ -530,18 +530,18 @@
 <!ENTITY ncurses-fin-du "46 MB">
 <!ENTITY ncurses-fin-sbu "0.2 SBU">
 
-<!ENTITY ninja-version "1.13.0">
-<!ENTITY ninja-size "285 KB">
+<!ENTITY ninja-version "1.13.1">
+<!ENTITY ninja-size "286 KB">
 <!ENTITY ninja-url "&github;/ninja-build/ninja/archive/v&ninja-version;/ninja-&ninja-version;.tar.gz">
-<!ENTITY ninja-md5 "a0f2016b736ee640b0473a679485e22e">
+<!ENTITY ninja-md5 "c35f8f55f4cf60f1a916068d8f45a0f8">
 <!ENTITY ninja-home "https://ninja-build.org/">
 <!ENTITY ninja-fin-du "37 MB">
 <!ENTITY ninja-fin-sbu "0.2 SBU">
 
-<!ENTITY openssl-version "3.5.0">
-<!ENTITY openssl-size "51,892 KB">
+<!ENTITY openssl-version "3.5.1">
+<!ENTITY openssl-size "51,913 KB">
 <!ENTITY openssl-url "&github;/openssl/openssl/releases/download/openssl-&openssl-version;/openssl-&openssl-version;.tar.gz">
-<!ENTITY openssl-md5 "51da7d2bdf7f4f508cb024f562eb9b03">
+<!ENTITY openssl-md5 "562a4e8d14ee5272f677a754b9c1ca5c">
 <!ENTITY openssl-home "https://www.openssl-library.org/">
 <!ENTITY openssl-fin-du "920 MB">
 <!ENTITY openssl-fin-sbu "1.8 SBU">
@@ -565,13 +565,13 @@
 <!ENTITY patch-fin-sbu "0.2 SBU">
 
 <!ENTITY perl-version-major "5">
-<!ENTITY perl-version-minor "40">
-<!ENTITY perl-version-patch "2">
+<!ENTITY perl-version-minor "42">
+<!ENTITY perl-version-patch "0">
 <!ENTITY perl-version-min "&perl-version-major;.&perl-version-minor;">
 <!ENTITY perl-version "&perl-version-major;.&perl-version-minor;.&perl-version-patch;">
-<!ENTITY perl-size "13,598 KB">
+<!ENTITY perl-size "14,084 KB">
 <!ENTITY perl-url "https://www.cpan.org/src/5.0/perl-&perl-version;.tar.xz">
-<!ENTITY perl-md5 "9ad7a269dc4053cdbeecd4fde444291b">
+<!ENTITY perl-md5 "7a6950a9f12d01eb96a9d2ed2f4e0072">
 <!ENTITY perl-home "https://www.perl.org/">
 <!ENTITY perl-tmp-du "285 MB">
 <!ENTITY perl-tmp-sbu "0.6 SBU">
@@ -619,11 +619,11 @@
 <!ENTITY python-docs-md5 "8f34b29779cc1d5d1e8c0a913c307129">
 <!ENTITY python-docs-size "10,130 KB">
 
-<!ENTITY readline-version "8.3-rc2">
+<!ENTITY readline-version "8.3">
 <!ENTITY readline-soversion "8.3"><!-- used for stripping -->
-<!ENTITY readline-size "3,338 KB">
+<!ENTITY readline-size "3,340 KB">
 <!ENTITY readline-url "&gnu;readline/readline-&readline-version;.tar.gz">
-<!ENTITY readline-md5 "d580a2ab42aa69d09c237b1e2058914d">
+<!ENTITY readline-md5 "25a73bfb2a3ad7146c5e9d4408d9f6cd">
 <!ENTITY readline-home "https://tiswww.case.edu/php/chet/readline/rltop.html">
 <!ENTITY readline-fin-du "16 MB">
 <!ENTITY readline-fin-sbu "mindre enn 0.1 SBU">

--- a/patches.ent
+++ b/patches.ent
@@ -35,9 +35,11 @@
 <!ENTITY kbd-backspace-patch-md5 "f75cca16a38da6caa7d52151f7136895">
 <!ENTITY kbd-backspace-patch-size "12 KB">
 
+<!--
 <!ENTITY perl-upstream-fix-patch "perl-&perl-version;-upstream_fix-1.patch">
 <!ENTITY perl-upstream-fix-patch-md5 "1983b48fee837a98db47fb5dba934744">
 <!ENTITY perl-upstream-fix-patch-size "13 KB">
+-->
 
 <!--
 <!ENTITY python-security-fixes-patch "Python-&python-version;-security_fixes-1.patch">


### PR DESCRIPTION
Oppdatering til readline-8.3. Oppdatering til perl-5.42.0. Oppdatering til openssl-3.5.1. Oppdatering til ninja-1.13.1. Oppdatering til linux-6.15.6. Oppdatering til gettext-0.25.1. Oppdatering til e2fsprogs-1.47.3. Oppdatering til bash-5.3.