### PR TITLE
Legg til en forklaring for --with-sysroot

### DIFF
--- a/chapter05/binutils-pass1.xml
+++ b/chapter05/binutils-pass1.xml
@@ -82,6 +82,16 @@ cd       build</userinput></screen>
     <variablelist>
       <title>Betydningen av konfigurasjonsalternativene:</title>
 
+      <note>
+        <para>
+          I motsetning til andre pakker vises ikke alle alternativene nedenfor 
+          når du kjører <command>./configure --help</command>. For eksempel, for 
+          å finne <option>--with-sysroot</option> alternativer, må du kjøre
+          <command>ld/configure --help</command>. Alle alternativene kan listes 
+          opp samtidig med <command>./configure --help=recursive</command>.
+        </para>
+      </note>
+
       <varlistentry>
         <term><parameter>--prefix=$LFS/tools</parameter></term>
         <listitem>


### PR DESCRIPTION
Det er brukere som med jevne mellomrom rapporterer at --with-sysroot alternativet ikke finnes i binutils og gcc. Legg til en merknad som forteller at ikke alle alternativer er synlige på toppnivået i treet, med mindre --help=recursive sendes. Ta --with-sysroot som et eksempel, slik at brukerne har alt de trenger for å finne det...