### PR TITLE
Pakkeoppdateringer.

### DIFF
--- a/chapter01/changelog.xml
+++ b/chapter01/changelog.xml
@@ -41,6 +41,48 @@
     -->
 
     <listitem>
+      <para>01.10.2025</para>
+      <itemizedlist>
+        <listitem>
+          <para>[bdubbs] - Oppdater til vim-9.1.1806. Addresserer
+          <ulink url='&lfs-ticket-root;5006'>#4500</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdater til iana-etc-20250926. Addresserer
+          <ulink url='&lfs-ticket-root;5006'>#5006</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdater til coreutils-9.8. Fikser
+          <ulink url='&lfs-ticket-root;5795'>#5795</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdater til expat-2.7.3 (Sikkerhetsutgivelse). Fikser
+          <ulink url='&lfs-ticket-root;5792'>#5792</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdater til linux-6.16.9. Fikser
+          <ulink url='&lfs-ticket-root;5796'>#5796</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdater til markupsafe-3.0.3. Fikser
+          <ulink url='&lfs-ticket-root;5801'>#5801</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdater til meson-1.9.1. Fikser
+          <ulink url='&lfs-ticket-root;5707'>#5797</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdater til openssl-3.5.3. Fikser
+          <ulink url='&lfs-ticket-root;5703'>#5793</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdater til util-linux-2.41.2. Fikser
+          <ulink url='&lfs-ticket-root;5708'>#5798</ulink>.</para>
+        </listitem>
+      </itemizedlist>
+    </listitem>
+
+    <listitem>
       <para>15.09.2025</para>
       <itemizedlist>
         <listitem>

--- a/chapter01/whatsnew.xml
+++ b/chapter01/whatsnew.xml
@@ -53,9 +53,9 @@
     <!--<listitem>
       <para>Bzip2-&bzip2-version;</para>
     </listitem>-->
-    <!--<listitem>
+    <listitem>
       <para>Coreutils-&coreutils-version;</para>
-    </listitem>-->
+    </listitem>
     <!--<listitem>
       <para>DejaGNU-&dejagnu-version;</para>
     </listitem>-->
@@ -68,9 +68,9 @@
     <!--<listitem>
        <para>E2fsprogs-&e2fsprogs-version;</para>
     </listitem>-->
-    <!--<listitem>
+    <listitem>
        <para>Expat-&expat-version;</para>
-    </listitem>-->
+    </listitem>
     <!--<listitem>
        <para>Expect-&expect-version;</para>
     </listitem>-->
@@ -182,9 +182,9 @@
     <!--<listitem>
       <para>Man-pages-&man-pages-version;</para>
     </listitem>-->
-    <!--<listitem>
+    <listitem>
       <para>MarkupSafe-&markupsafe-version;</para>
-    </listitem>-->
+    </listitem>
     <listitem>
       <para>Meson-&meson-version;</para>
     </listitem>
@@ -200,9 +200,9 @@
     <!--<listitem>
       <para>Ninja-&ninja-version;</para>
     </listitem>-->
-    <!--<listitem>
+    <listitem>
       <para>OpenSSL-&openssl-version;</para>
-    </listitem>-->
+    </listitem>
     <!--<listitem>
       <para>Patch-&patch-version;</para>
     </listitem>-->
@@ -263,9 +263,9 @@
     <!--<listitem revision="sysv">
       <para>Udev from Systemd-&systemd-version;</para>
     </listitem>-->
-    <!--<listitem>
+    <listitem>
       <para>Util-linux-&util-linux-version;</para>
-    </listitem>-->
+    </listitem>
     <listitem>
       <para>Vim-&vim-version;</para>
     </listitem>
@@ -298,13 +298,14 @@
   <itemizedlist>
     <title>Lagt til:</title>
     <listitem><para></para></listitem>  <!-- satisfy build -->
-    <listitem><para>Pcre2-&pcre2-version;</para></listitem>  <!-- satisfy build -->
-    <listitem><para>Sqlite-&sqlite-version;</para></listitem>  <!-- satisfy build -->
+    <listitem><para>Coreutils-9.8-i18n-2.patch</para></listitem> 
   </itemizedlist>
 
   <itemizedlist>
     <title>Fjernet:</title>
     <listitem><para></para></listitem>  <!-- satisfy build -->
+    <listitem><para>Coreutils-9.7-i18n-1.patch</para></listitem>  
+    <listitem><para>Coreutils-9.7-upstream_fix-1.patch</para></listitem>  
   </itemizedlist>
 
 </sect1>

--- a/chapter03/patches.xml
+++ b/chapter03/patches.xml
@@ -52,14 +52,6 @@
     </varlistentry>
 
     <varlistentry>
-      <term>Coreutils Upstream Fix Patch - <token>&coreutils-upstream-patch-size;</token>:</term>
-      <listitem>
-        <para>Nedlasting: <ulink url="&patches-root;&coreutils-upstream-patch;"/></para>
-        <para>MD5 sum: <literal>&coreutils-upstream-patch-md5;</literal></para>
-      </listitem>
-    </varlistentry>
-
-    <varlistentry>
       <term>Coreutils Internationalization Fixes Patch - <token>&coreutils-i18n-patch-size;</token>:</term>
       <listitem>
         <para>Nedlasting: <ulink url="&patches-root;&coreutils-i18n-patch;"/></para>

--- a/chapter08/coreutils.xml
+++ b/chapter08/coreutils.xml
@@ -41,10 +41,6 @@
   <sect2 role="installation">
     <title>Installasjon av Coreutils</title>
 
-    <para>Først må du installere en oppdatering for et sikkerhetsproblem som er identifisert oppstrøms:</para>
-
-<screen><userinput remap="pre">patch -Np1 -i ../&coreutils-upstream-patch;</userinput></screen>
-
     <para>POSIX krever at programmer fra Coreutils gjenkjenner karaktergrenser
     riktig selv i multibyte lokaliteter. Følgende oppdateringer
     fikser dette misligholdet og andre internasjonaliseringsrelaterte feil.</para>

--- a/chapter08/util-linux.xml
+++ b/chapter08/util-linux.xml
@@ -41,12 +41,7 @@
 
   <sect2 role="installation">
     <title>Installasjon av Util-linux</title>
-	
-<!--
-    <para>Først deaktiver en problematisk test:</para>
 
-    <screen><userinput remap="pre">sed -i '/test_mkfds/s/^/#/' tests/helpers/Makemodule.am</userinput></screen>
--->
     <para>Forbered Util-linux for kompilering:</para>
 
     <screen revision="sysv"><userinput remap="configure">./configure --bindir=/usr/bin     \
@@ -127,20 +122,16 @@ su tester -c "make -k check"</userinput></screen>
        mislykkes hvis kjernealternativet <option>CONFIG_NETLINK_DIAG</option> ikke er
        aktivert.
     </para>
-
+<!--
     <para>
       En test, kill: decode functions, er kjent for å mislykkes 
       med bash-5.3-rc1 eller nyere.
     </para>
-
+-->
     <para>Installer pakken:</para>
 
 <screen><userinput remap="install">make install</userinput></screen>
-<!--
-  <para>Til slutt, installer manualsidene:</para>
 
-<screen><userinput remap="install">tar -xf ../util-linux-man-pages-&util-linux-version;.tar.xz - -directory /usr/share/man - -strip-components=1</userinput></screen>
--->
   </sect2>
 
   <sect2 id="contents-utillinux" role="content">

--- a/chapter08/vim.xml
+++ b/chapter08/vim.xml
@@ -84,6 +84,8 @@ sed '/test_plugin_glvs/d' -i src/testdir/Make_all.mak</userinput></screen>
     vellykket test vil resultere i ordene <computeroutput>ALL
     DONE</computeroutput> i loggfilen ved ferdigstillelse.</para>
 
+    <para>En test, test_matchfuzzy.vim, er kjent for å feile på noen systemer.</para>
+
     <para>Installer pakken:</para>
 
 <screen><userinput remap="install">make install</userinput></screen>

--- a/packages.ent
+++ b/packages.ent
@@ -96,10 +96,10 @@
 <!ENTITY bzip2-fin-du "7.3 MB">
 <!ENTITY bzip2-fin-sbu "mindre enn 0.1 SBU">
 
-<!ENTITY coreutils-version "9.7">
-<!ENTITY coreutils-size "6,015 KB">
+<!ENTITY coreutils-version "9.8">
+<!ENTITY coreutils-size "6,089 KB">
 <!ENTITY coreutils-url "&gnu;coreutils/coreutils-&coreutils-version;.tar.xz">
-<!ENTITY coreutils-md5 "6b7285faf7d5eb91592bdd689270d3f1">
+<!ENTITY coreutils-md5 "b2e687b6e664b9dd76581836c5c3e782">
 <!ENTITY coreutils-home "&gnu-software;coreutils/">
 <!ENTITY coreutils-tmp-du "181 MB">
 <!ENTITY coreutils-tmp-sbu "0.3 SBU">
@@ -148,10 +148,10 @@
 <!ENTITY elfutils-fin-du "156 MB">
 <!ENTITY elfutils-fin-sbu "0.3 SBU">
 
-<!ENTITY expat-version "2.7.1">
-<!ENTITY expat-size "485 KB">
+<!ENTITY expat-version "2.7.3">
+<!ENTITY expat-size "493 KB">
 <!ENTITY expat-url "&github;/libexpat/libexpat/releases/download/R_2_7_1/expat-&expat-version;.tar.xz">
-<!ENTITY expat-md5 "9f0c266ff4b9720beae0c6bd53ae4469">
+<!ENTITY expat-md5 "423975a2a775ff32f12c53635b463a91">
 <!ENTITY expat-home "https://libexpat.github.io/">
 <!ENTITY expat-fin-du "14 MB">
 <!ENTITY expat-fin-sbu "0.1 SBU">
@@ -309,10 +309,10 @@
 <!ENTITY gzip-fin-du "21 MB">
 <!ENTITY gzip-fin-sbu "0.1 SBU">
 
-<!ENTITY iana-etc-version "20250826">
+<!ENTITY iana-etc-version "20250926">
 <!ENTITY iana-etc-size "593 KB">
 <!ENTITY iana-etc-url "https://github.com/Mic92/iana-etc/releases/download/&iana-etc-version;/iana-etc-&iana-etc-version;.tar.gz">
-<!ENTITY iana-etc-md5 "caed93e08bd7911b7a1d616411f28065">
+<!ENTITY iana-etc-md5 "437a3e9f4a420244c90db4ab20e713b6">
 <!ENTITY iana-etc-home "https://www.iana.org/protocols">
 <!ENTITY iana-etc-fin-du "4.8 MB">
 <!ENTITY iana-etc-fin-sbu "mindre enn 0.1 SBU">
@@ -424,12 +424,12 @@
 <!ENTITY linux-major-version "6">
 <!ENTITY linux-minor-version "16">
 <!ENTITY linux-majmin-version "&linux-major-version;.&linux-minor-version;">
-<!ENTITY linux-patch-version "7">
+<!ENTITY linux-patch-version "9">
 <!--<!ENTITY linux-version "&linux-major-version;.&linux-minor-version;">-->
 <!ENTITY linux-version "&linux-major-version;.&linux-minor-version;.&linux-patch-version;">
-<!ENTITY linux-size "149,096 KB">
+<!ENTITY linux-size "149,102 KB">
 <!ENTITY linux-url "&kernel;linux/kernel/v&linux-major-version;.x/linux-&linux-version;.tar.xz">
-<!ENTITY linux-md5 "890ccdaac06e063931654dd7a78a180a">
+<!ENTITY linux-md5 "feb0a3d5ecf5a4628aed7d9f8f7ab3f6">
 <!ENTITY linux-home "https://www.kernel.org/">
 <!-- measured for 6.10.1 / gcc-14.1.0 on x86_64 with -j4 : 
  minimum is allnoconfig 
@@ -488,18 +488,18 @@
 <!ENTITY man-pages-fin-du "52 MB">
 <!ENTITY man-pages-fin-sbu "0.1 SBU">
 
-<!ENTITY markupsafe-version "3.0.2">
-<!ENTITY markupsafe-size "21 KB">
+<!ENTITY markupsafe-version "3.0.3">
+<!ENTITY markupsafe-size "79 KB">
 <!ENTITY markupsafe-url "&pypi-src;/M/MarkupSafe/markupsafe-&markupsafe-version;.tar.gz">
-<!ENTITY markupsafe-md5 "cb0071711b573b155cc8f86e1de72167">
+<!ENTITY markupsafe-md5 "13a73126d25afa72a1ff0daed072f5fe">
 <!ENTITY markupsafe-home "https://palletsprojects.com/p/markupsafe/">
 <!ENTITY markupsafe-fin-du "500 KB">
 <!ENTITY markupsafe-fin-sbu "mindre enn 0.1 SBU">
 
-<!ENTITY meson-version "1.9.0">
-<!ENTITY meson-size "2,311 KB">
+<!ENTITY meson-version "1.9.1">
+<!ENTITY meson-size "4,964 KB">
 <!ENTITY meson-url "&github;/mesonbuild/meson/releases/download/&meson-version;/meson-&meson-version;.tar.gz">
-<!ENTITY meson-md5 "ed30f3221e15bc2dbafbdfaa1a55926e">
+<!ENTITY meson-md5 "19e0a1091cec23d369dd77d852844195">
 <!ENTITY meson-home "https://mesonbuild.com">
 <!ENTITY meson-fin-du "45 MB">
 <!ENTITY meson-fin-sbu "mindre enn 0.1 SBU">
@@ -539,10 +539,10 @@
 <!ENTITY ninja-fin-du "43 MB">
 <!ENTITY ninja-fin-sbu "0.2 SBU">
 
-<!ENTITY openssl-version "3.5.2">
-<!ENTITY openssl-size "51,934 KB">
+<!ENTITY openssl-version "3.5.3">
+<!ENTITY openssl-size "51,937 KB">
 <!ENTITY openssl-url "&github;/openssl/openssl/releases/download/openssl-&openssl-version;/openssl-&openssl-version;.tar.gz">
-<!ENTITY openssl-md5 "890fc59f86fc21b5e4d1c031a698dbde">
+<!ENTITY openssl-md5 "0ec20faeb96bbb203c8684cc7fe4432e">
 <!ENTITY openssl-home "https://www.openssl-library.org/">
 <!ENTITY openssl-fin-du "1.1 GB">
 <!ENTITY openssl-fin-sbu "1.9 SBU">
@@ -758,20 +758,20 @@
 <!ENTITY udev-fin-sbu "0.1 SBU">
 
 <!ENTITY util-linux-minor "2.41">
-<!ENTITY util-linux-version "2.41.1"> <!-- 2.33.x -->
-<!ENTITY util-linux-size "9,382 KB">
+<!ENTITY util-linux-version "2.41.2"> <!-- 2.33.x -->
+<!ENTITY util-linux-size "9,388 KB">
 <!ENTITY util-linux-url "&kernel;linux/utils/util-linux/v&util-linux-minor;/util-linux-&util-linux-version;.tar.xz">
-<!ENTITY util-linux-md5 "7e5e68845e2f347cf96f5448165f1764">
+<!ENTITY util-linux-md5 "a2a3281ce76821c4bc28794fdf9d3994">
 <!ENTITY util-linux-home "https://git.kernel.org/pub/scm/utils/util-linux/util-linux.git/">
 <!ENTITY util-linux-tmp-du "192 MB">
 <!ENTITY util-linux-tmp-sbu "0.2 SBU">
 <!ENTITY util-linux-fin-du "346 MB">
 <!ENTITY util-linux-fin-sbu "0.5 SBU">
 
-<!ENTITY vim-version "9.1.1754">
+<!ENTITY vim-version "9.1.1806">
 <!-- <!ENTITY vim-majmin "90"> -->
 <!ENTITY vim-docdir "vim/vim91">
-<!ENTITY vim-size "18,346 KB">
+<!ENTITY vim-size "18,368 KB">
 <!ENTITY vim-url "https://github.com/vim/vim/archive/v&vim-version;/vim-&vim-version;.tar.gz">
 <!-- N.B. LFS 9.0 uses
      https://github.com/vim/vim/archive/v8.1.1846/vim-8.1.1846.tar.gz
@@ -785,7 +785,7 @@
      example, https://github.com/vim/vim/tags?after=v8.1.1847 will show
      us v8.1.1846. -->
 <!--<!ENTITY vim-url "&anduin-sources;/vim-&vim-version;.tar.gz">-->
-<!ENTITY vim-md5 "e6ab375bffe8f741577e55d771c3730e">
+<!ENTITY vim-md5 "e72f31be182f1ccf4b66bef46ac1e60e">
 <!ENTITY vim-home "https://www.vim.org">
 <!ENTITY vim-fin-du "259 MB">
 <!ENTITY vim-fin-sbu "3.7 SBU">

--- a/patches.ent
+++ b/patches.ent
@@ -15,13 +15,9 @@
 <!ENTITY bzip2-docs-patch-md5 "6a5ac7e89b791aae556de0f745916f7f">
 <!ENTITY bzip2-docs-patch-size "1.6 KB">
 
-<!ENTITY coreutils-i18n-patch "coreutils-&coreutils-version;-i18n-1.patch">
-<!ENTITY coreutils-i18n-patch-md5 "33ebfad32b2dfb8417c3335c08671206">
-<!ENTITY coreutils-i18n-patch-size "159 KB">
-
-<!ENTITY coreutils-upstream-patch "coreutils-&coreutils-version;-upstream_fix-1.patch">
-<!ENTITY coreutils-upstream-patch-md5 "96382a5aa85d6651a74f94ffb61785d9">
-<!ENTITY coreutils-upstream-patch-size "4.1 KB">
+<!ENTITY coreutils-i18n-patch "coreutils-&coreutils-version;-i18n-2.patch">
+<!ENTITY coreutils-i18n-patch-md5 "c800540039fb0707954197486b1bde70">
+<!ENTITY coreutils-i18n-patch-size "128 KB">
 
 <!ENTITY expect-gcc15-patch "expect-&expect-version;-gcc15-1.patch">
 <!ENTITY expect-gcc15-patch-md5 "0ca4d6bb8d572fbcdb13cb36cd34833e">


### PR DESCRIPTION
Oppdatering til vim-9.1.1806. Oppdatering til iana-etc-20250926. Oppdatering til coreutils-9.8.
Oppdatering til expat-2.7.3 (sikkerhetsutgivelse). Oppdatering til linux-6.16.9.
Oppdatering til markupsafe-3.0.3.
Oppdatering til meson-1.9.1.
Oppdatering til openssl-3.5.3.
Oppdatering til util-linux-2.41.2.