### PR TITLE
Pakkeoppdateringer.

### DIFF
--- a/chapter01/changelog.xml
+++ b/chapter01/changelog.xml
@@ -41,6 +41,36 @@
     -->
 
     <listitem>
+      <para>15.10.2025</para>
+      <itemizedlist>
+        <listitem>
+          <para>[bdubbs] - Oppdater til less-685. Fikser
+          <ulink url='&lfs-ticket-root;5810'>#5810</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdater til systemd-258.1. Fikser
+          <ulink url='&lfs-ticket-root;5809'>#5809</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdater til Python-3.14.0. Fikser
+          <ulink url='&lfs-ticket-root;5806'>#5806</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Update to openssl-3.6.0. Fikser
+          <ulink url='&lfs-ticket-root;5804'>#5804</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdater til linux-6.17.2. Fikser
+          <ulink url='&lfs-ticket-root;5802'>#5802</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdater til iproute2-6.17.0. Fikser
+          <ulink url='&lfs-ticket-root;5803'>#5803</ulink>.</para>
+        </listitem>
+      </itemizedlist>
+    </listitem>
+
+    <listitem>
       <para>01.10.2025</para>
       <itemizedlist>
         <listitem>

--- a/chapter01/whatsnew.xml
+++ b/chapter01/whatsnew.xml
@@ -128,9 +128,9 @@
     <!--<listitem>
       <para>Intltool-&intltool-version;</para>
     </listitem>-->
-    <!--<listitem>
+    <listitem>
       <para>IPRoute2-&iproute2-version;</para>
-    </listitem>-->
+    </listitem>
     <!--<listitem>
       <para>Jinja2-&jinja2-version;</para>
     </listitem>-->
@@ -140,9 +140,9 @@
     <!--<listitem>
       <para>Kmod-&kmod-version;</para>
     </listitem>-->
-    <!--<listitem>
+    <listitem>
       <para>Less-&less-version;</para>
-    </listitem>-->
+    </listitem>
     <!--<listitem>
       <para>LFS-Bootscripts-&lfs-bootscripts-version;</para>
     </listitem>-->
@@ -221,9 +221,9 @@
     <!--<listitem>
       <para>Psmisc-&psmisc-version;</para>
     </listitem>-->
-    <!--<listitem>
+    <listitem>
       <para>Python-&python-version;</para>
-    </listitem>-->
+    </listitem>
     <!--<listitem>
       <para>Readline-&readline-version;</para>
     </listitem>-->

--- a/chapter08/python.xml
+++ b/chapter08/python.xml
@@ -89,8 +89,7 @@
     og 1 SBU (målt når du bygger Binutils pass 1 med én CPU
     kjerne) bør være nok. Noen tester er rare, så testpakken vil automatisk
     kjøre mislykkede tester på nytt. Hvis en test mislyktes, men deretter består
-    når den kjøres på nytt, bør den anses som bestått.  En test, test_ssl,
-    er kjent for å mislykkes i chroot miljøet.</para>
+    når den kjøres på nytt, bør den anses som bestått.</para>
 
     <para>Installer pakken:</para>
 

--- a/chapter08/udev.xml
+++ b/chapter08/udev.xml
@@ -55,11 +55,11 @@
     <para>Fjern en udevregel som krever en full Systemd installasjon:</para>
 
  <screen><userinput remap="pre">sed -i '/systemd-sysctl/s/^/#/' rules.d/99-systemd.rules.in</userinput></screen>
-
+<!-- Not needed in 258.1
     <para>Rett en feil som hindrer udev i å kjøre riktig:</para>
 
 <screen><userinput remap="pre">sed -i "/udev_dependencies,/a \                'link_with': udev_link_with," src/udev/meson.build</userinput></screen>
-
+-->
     <para>Juster de hardkodede banene til nettverkskonfigurasjonsfiler for
     frittstående udev installasjon:</para>
 

--- a/packages.ent
+++ b/packages.ent
@@ -333,10 +333,10 @@
 <!ENTITY intltool-fin-du "1.5 MB">
 <!ENTITY intltool-fin-sbu "mindre enn 0.1 SBU">
 
-<!ENTITY iproute2-version "6.16.0">
-<!ENTITY iproute2-size "910 KB">
+<!ENTITY iproute2-version "6.17.0">
+<!ENTITY iproute2-size "919 KB">
 <!ENTITY iproute2-url "&kernel;linux/utils/net/iproute2/iproute2-&iproute2-version;.tar.xz">
-<!ENTITY iproute2-md5 "80e1f91bf59d572acc15d5c6eb4f3e7c">
+<!ENTITY iproute2-md5 "7cecf99ef6877bddd958539c4160eaf6">
 <!ENTITY iproute2-home "&kernel;linux/utils/net/iproute2/">
 <!ENTITY iproute2-fin-du "17 MB">
 <!ENTITY iproute2-fin-sbu "0.1 SBU">
@@ -365,10 +365,10 @@
 <!ENTITY kmod-fin-du "6.7 MB">
 <!ENTITY kmod-fin-sbu "mindre enn 0.1 SBU">
 
-<!ENTITY less-version "679">
-<!ENTITY less-size "857 KB">
+<!ENTITY less-version "685">
+<!ENTITY less-size "862 KB">
 <!ENTITY less-url "https://www.greenwoodsoftware.com/less/less-&less-version;.tar.gz">
-<!ENTITY less-md5 "0386dc14f6a081a94dfb4c2413864eed">
+<!ENTITY less-md5 "08bd7e4cd067ec19b755726ca4544d65">
 <!ENTITY less-home "https://www.greenwoodsoftware.com/less/">
 <!ENTITY less-fin-du "16 MB">
 <!ENTITY less-fin-sbu "mindre enn 0.1 SBU">
@@ -422,14 +422,14 @@
 <!ENTITY libxcrypt-fin-sbu "0.1 SBU">
 
 <!ENTITY linux-major-version "6">
-<!ENTITY linux-minor-version "16">
+<!ENTITY linux-minor-version "17">
 <!ENTITY linux-majmin-version "&linux-major-version;.&linux-minor-version;">
-<!ENTITY linux-patch-version "9">
+<!ENTITY linux-patch-version "3">
 <!--<!ENTITY linux-version "&linux-major-version;.&linux-minor-version;">-->
 <!ENTITY linux-version "&linux-major-version;.&linux-minor-version;.&linux-patch-version;">
-<!ENTITY linux-size "149,102 KB">
+<!ENTITY linux-size "149,748 KB">
 <!ENTITY linux-url "&kernel;linux/kernel/v&linux-major-version;.x/linux-&linux-version;.tar.xz">
-<!ENTITY linux-md5 "feb0a3d5ecf5a4628aed7d9f8f7ab3f6">
+<!ENTITY linux-md5 "50a1cc4b00a3a0fcdb63a75e63def877">
 <!ENTITY linux-home "https://www.kernel.org/">
 <!-- measured for 6.10.1 / gcc-14.1.0 on x86_64 with -j4 : 
  minimum is allnoconfig 
@@ -539,10 +539,10 @@
 <!ENTITY ninja-fin-du "43 MB">
 <!ENTITY ninja-fin-sbu "0.2 SBU">
 
-<!ENTITY openssl-version "3.5.4">
-<!ENTITY openssl-size "51,944 KB">
+<!ENTITY openssl-version "3.6.0">
+<!ENTITY openssl-size "53,686 KB">
 <!ENTITY openssl-url "&github;/openssl/openssl/releases/download/openssl-&openssl-version;/openssl-&openssl-version;.tar.gz">
-<!ENTITY openssl-md5 "570a7ab371147b6ba72c6d0fed93131f">
+<!ENTITY openssl-md5 "77ab78417082f22a2ce809898bd44da0">
 <!ENTITY openssl-home "https://www.openssl-library.org/">
 <!ENTITY openssl-fin-du "1.1 GB">
 <!ENTITY openssl-fin-sbu "1.9 SBU">
@@ -614,19 +614,19 @@
 <!-- If python minor version changes, updates in python and
      meson pages will be needed: python3.6 and python3.6m -->
 
-<!ENTITY python-version "3.13.7">
-<!ENTITY python-minor "3.13">
-<!ENTITY python-size "22,236 KB">
+<!ENTITY python-version "3.14.0">
+<!ENTITY python-minor "3.14">
+<!ENTITY python-size "23,043 KB">
 <!ENTITY python-url "https://www.python.org/ftp/python/&python-version;/Python-&python-version;.tar.xz">
-<!ENTITY python-md5 "256cdb3bbf45cdce7499e52ba6c36ea3">
+<!ENTITY python-md5 "41389edaf9c643263cbed9b5ed307df8">
 <!ENTITY python-home "https://www.python.org/">
 <!ENTITY python-tmp-du "546 MB">
 <!ENTITY python-tmp-sbu "0.5 SBU">
 <!ENTITY python-fin-du "453 MB">
 <!ENTITY python-fin-sbu "2.0 SBU">
 <!ENTITY python-docs-url "https://www.python.org/ftp/python/doc/&python-version;/python-&python-version;-docs-html.tar.bz2">
-<!ENTITY python-docs-md5 "b84c0d81b2758398bb7f5b7411d3d908">
-<!ENTITY python-docs-size "10,183 KB">
+<!ENTITY python-docs-md5 "658b4f9a0f720f161cf6b3f5798a8139">
+<!ENTITY python-docs-size "10,568 KB">
 
 <!ENTITY readline-version "8.3">
 <!ENTITY readline-soversion "8.3"><!-- used for stripping -->
@@ -685,21 +685,21 @@
 <!ENTITY sysklogd-fin-du "3.9 MB">
 <!ENTITY sysklogd-fin-sbu "mindre enn 0.1 SBU">
 
-<!ENTITY systemd-version  "258">
+<!ENTITY systemd-version  "258.1">
 <!--<!ENTITY systemd-stable   "6b4878d">-->
 <!-- The above entity is used whenever we move to a stable backport branch. 
      In the event of a critical problem or kernel change that is incompatible, 
      we will switch to the backport branch until the next stable release. -->
-<!ENTITY systemd-size     "16,580 KB">
+<!ENTITY systemd-size     "16,585 KB">
 <!ENTITY systemd-url      "&github;/systemd/systemd/archive/v&systemd-version;/systemd-&systemd-version;.tar.gz">
 <!--<!ENTITY systemd-url      "&anduin-sources;/systemd-&systemd-version;-&systemd-stable;.tar.xz">-->
-<!ENTITY systemd-md5      "490c1c2bbe5b576ff9ca2848fbd31507">
+<!ENTITY systemd-md5      "e7bf839c380533a5039bd940181c5d6b">
 <!ENTITY systemd-home     "https://systemd.io">
-<!ENTITY systemd-man-version "258">
-<!ENTITY systemd-man-size "768 KB">
+<!ENTITY systemd-man-version "258.1">
+<!ENTITY systemd-man-size "765 KB">
 <!--<!ENTITY systemd-man-url  "&anduin-sources;/systemd-man-pages-&systemd-version;-&systemd-stable;.tar.xz">-->
 <!ENTITY systemd-man-url  "&anduin-sources;/systemd-man-pages-&systemd-man-version;.tar.xz">
-<!ENTITY systemd-man-md5  "688045e26e6121dd8f7b9abf788e47d9">
+<!ENTITY systemd-man-md5  "3f748dd5a2047aa8ac6e79f0b03175be">
 <!ENTITY systemd-fin-du   "337 MB">
 <!ENTITY systemd-fin-sbu  "1.4 SBU">
 


### PR DESCRIPTION
Oppdater til less-685.
Oppdater til systemd-258.1.
Oppdater til Python-3.14.0.
Oppdater til openssl-3.6.0.
Oppdater til linux-6.17.2.
Oppdater til iproute2-6.17.0.