### PR TITLE
Pakkeoppdateringer.

### DIFF
--- a/chapter01/changelog.xml
+++ b/chapter01/changelog.xml
@@ -41,6 +41,33 @@
     -->
 
     <listitem>
+      <para>15.11.2025</para>
+      <itemizedlist>
+        <listitem>
+          <para>[bdubbs] - Oppdater til coreutils-9.9. Fikser
+          <ulink url='&lfs-ticket-root;5823'>#5823</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdater til binutils-2.45.1. 
+          Dette krever nå glibc-2.42-upstream_fixes-1.patch. Fikser
+          <ulink url='&lfs-ticket-root;5824'>#5824</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdater til libxcrypt-4.5.1. Fikser
+          <ulink url='&lfs-ticket-root;5820'>#5820</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdater til linux-6.17.8. Fikser
+          <ulink url='&lfs-ticket-root;5818'>#5818</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdater til sqlite-autoconf-3510000 (3.51.0). Fikser
+          <ulink url='&lfs-ticket-root;5821'>#5821</ulink>.</para>
+        </listitem>
+      </itemizedlist>
+    </listitem>
+
+    <listitem>
       <para>01.11.2025</para>
       <itemizedlist>
         <listitem>

--- a/chapter01/whatsnew.xml
+++ b/chapter01/whatsnew.xml
@@ -44,9 +44,9 @@
     <!--<listitem>
       <para>Bc-&bc-version;</para>
     </listitem>-->
-    <!--<listitem>
+    <listitem>
       <para>Binutils-&binutils-version;</para>
-    </listitem>-->
+    </listitem>
     <!--<listitem>
       <para>Bison-&bison-version;</para>
     </listitem>-->
@@ -161,9 +161,9 @@
     <!--<listitem>
       <para>Libtool-&libtool-version;</para>
     </listitem>-->
-    <!--<listitem>
+    <listitem>
       <para>Libxcrypt-&libxcrypt-version;</para>
-    </listitem>-->
+    </listitem>
     <listitem>
       <para>Linux-&linux-version;</para>
     </listitem>
@@ -236,9 +236,9 @@
     <!--<listitem>
       <para>Shadow-&shadow-version;</para>
     </listitem>-->
-    <!--<listitem>
+    <listitem>
       <para>Sqlite-&sqlite-version;</para>
-    </listitem>-->
+    </listitem>
     <!--<listitem revision="sysv">
       <para>Sysklogd-&sysklogd-version;</para>
     </listitem>-->
@@ -298,7 +298,8 @@
   <itemizedlist>
     <title>Lagt til:</title>
     <listitem><para></para></listitem>  <!-- satisfy build -->
-    <listitem><para>Coreutils-9.8-i18n-2.patch</para></listitem> 
+    <listitem><para>Coreutils-9.9-i18n-1.patch</para></listitem> 
+    <listitem><para>Glibc-2.42-upstream_fixes-1.patch</para></listitem> 
   </itemizedlist>
 
   <itemizedlist>

--- a/chapter03/patches.xml
+++ b/chapter03/patches.xml
@@ -76,7 +76,7 @@
       </listitem>
     </varlistentry>
 -->
-<!--
+
     <varlistentry>
       <term>Glibc Upstream Fix Patch - <token>&glibc-upstream-patch-size;</token>:</term>
       <listitem>
@@ -84,7 +84,7 @@
         <para>MD5 sum: <literal>&glibc-upstream-patch-md5;</literal></para>
       </listitem>
     </varlistentry>
--->
+
     <varlistentry>
       <term>Glibc FHS Patch - <token>&glibc-fhs-patch-size;</token>:</term>
       <listitem>

--- a/chapter08/glibc.xml
+++ b/chapter08/glibc.xml
@@ -43,6 +43,10 @@
   <sect2 role="installation">
     <title>Installation of Glibc</title>
 
+    <para>Først, bruk noen endringer fra oppstrøms:</para>
+
+<screen><userinput remap="pre">patch -Np1 -i ../&glibc-upstream-patch;</userinput></screen>
+
     <para>Noen av Glibc programmene bruker ikke-FHS kompatible
     <filename class="directory">/var/db</filename> mappen til å lagre
     kjøretidsdataene i. Bruk følgende oppdatering for å forsikre om at slike programmer
@@ -167,11 +171,13 @@ esac</userinput></screen>
       </listitem>
 
       <!-- https://sourceware.org/pipermail/libc-alpha/2025-August/169612.html -->
+      <!-- Looks like this is fixed. No failures for version 2.42 with th upstream patch.
       <listitem>
         <para><emphasis>misc/tst-preadvwritev2</emphasis> og
         <emphasis>misc/tst-preadvwritev64v2</emphasis> er kjent for å feile hvis 
         vertskjernen er Linux-6.14 eller nyere.</para>
       </listitem>
+      -->
 
       <listitem>
         <para>Noen tester, for eksempel

--- a/chapter08/systemd.xml
+++ b/chapter08/systemd.xml
@@ -241,7 +241,7 @@ ninja test</userinput></screen>
     <!-- Please make sure systemd man pages tarball has a common leading
          component in the path.  -->
 <screen><userinput remap="install">tar -xf ../../systemd-man-pages-&systemd-man-version;.tar.xz \
-    --no-same-owner --strip-components=1   \
+    --no-same-owner --strip-components=1     \
     -C /usr/share/man</userinput></screen>
 
     <para>Opprett filen <filename>/etc/machine-id</filename> som trengs av

--- a/chapter08/udev.xml
+++ b/chapter08/udev.xml
@@ -173,7 +173,7 @@ make -f &udev-lfs-version;/Makefile.lfs install</userinput></screen>
 
     <!-- Please make sure systemd man pages tarball has a common leading
          component in the path.  -->
-<screen><userinput remap="install">tar -xf ../../systemd-man-pages-&systemd-man-version;.tar.xz                            \
+<screen><userinput remap="install">tar -xf ../../systemd-man-pages-&systemd-man-version;.tar.xz                          \
     --no-same-owner --strip-components=1                              \
     -C /usr/share/man --wildcards '*/udev*' '*/libudev*'              \
                                   '*/systemd.link.5'                  \

--- a/packages.ent
+++ b/packages.ent
@@ -65,10 +65,10 @@
 <!ENTITY bc-fin-du "7.8 MB">
 <!ENTITY bc-fin-sbu "mindre enn 0.1 SBU">
 
-<!ENTITY binutils-version "2.45">
-<!ENTITY binutils-size "27,216 KB">
+<!ENTITY binutils-version "2.45.1">
+<!ENTITY binutils-size "27,307 KB">
 <!ENTITY binutils-url "https://sourceware.org/pub/binutils/releases/binutils-&binutils-version;.tar.xz">
-<!ENTITY binutils-md5 "dee5b4267e0305a99a3c9d6131f45759">
+<!ENTITY binutils-md5 "ff59f8dc1431edfa54a257851bea74e7">
 <!ENTITY binutils-home "&gnu-software;binutils/">
 <!ENTITY binutils-tmpp1-du "678 MB">
 <!ENTITY binutils-tmpp1-sbu "1 SBU">
@@ -96,10 +96,10 @@
 <!ENTITY bzip2-fin-du "7.3 MB">
 <!ENTITY bzip2-fin-sbu "mindre enn 0.1 SBU">
 
-<!ENTITY coreutils-version "9.8">
-<!ENTITY coreutils-size "6,089 KB">
+<!ENTITY coreutils-version "9.9">
+<!ENTITY coreutils-size "6,148 KB">
 <!ENTITY coreutils-url "&gnu;coreutils/coreutils-&coreutils-version;.tar.xz">
-<!ENTITY coreutils-md5 "b2e687b6e664b9dd76581836c5c3e782">
+<!ENTITY coreutils-md5 "ce613d0dae179f4171966ecd0a898ec4">
 <!ENTITY coreutils-home "&gnu-software;coreutils/">
 <!ENTITY coreutils-tmp-du "181 MB">
 <!ENTITY coreutils-tmp-sbu "0.3 SBU">
@@ -413,10 +413,10 @@
 <!ENTITY libtool-fin-du "44 MB">
 <!ENTITY libtool-fin-sbu "0.6 SBU">
 
-<!ENTITY libxcrypt-version "4.4.38">
-<!ENTITY libxcrypt-size "612 KB">
+<!ENTITY libxcrypt-version "4.5.1">
+<!ENTITY libxcrypt-size "655 KB">
 <!ENTITY libxcrypt-url "&github;/besser82/libxcrypt/releases/download/v&libxcrypt-version;/libxcrypt-&libxcrypt-version;.tar.xz">
-<!ENTITY libxcrypt-md5 "1796a5d20098e9dd9e3f576803c83000">
+<!ENTITY libxcrypt-md5 "7be4cacda2055aa41133f7a577512a08">
 <!ENTITY libxcrypt-home "&github;/besser82/libxcrypt/">
 <!ENTITY libxcrypt-fin-du "12 MB">
 <!ENTITY libxcrypt-fin-sbu "0.1 SBU">
@@ -424,12 +424,12 @@
 <!ENTITY linux-major-version "6">
 <!ENTITY linux-minor-version "17">
 <!ENTITY linux-majmin-version "&linux-major-version;.&linux-minor-version;">
-<!ENTITY linux-patch-version "6">
+<!ENTITY linux-patch-version "8">
 <!--<!ENTITY linux-version "&linux-major-version;.&linux-minor-version;">-->
 <!ENTITY linux-version "&linux-major-version;.&linux-minor-version;.&linux-patch-version;">
-<!ENTITY linux-size "149,748 KB">
+<!ENTITY linux-size "149,793 KB">
 <!ENTITY linux-url "&kernel;linux/kernel/v&linux-major-version;.x/linux-&linux-version;.tar.xz">
-<!ENTITY linux-md5 "23443e9140171bd424dd71187b425fda">
+<!ENTITY linux-md5 "74c34fafb5914d05447863cdc304ab55">
 <!ENTITY linux-home "https://www.kernel.org/">
 <!-- measured for 6.10.1 / gcc-14.1.0 on x86_64 with -j4 : 
  minimum is allnoconfig 
@@ -663,19 +663,19 @@
 <!ENTITY shadow-fin-du "115 MB">
 <!ENTITY shadow-fin-sbu "0.1 SBU">
 
-<!ENTITY sqlite-version "3500400">
-<!ENTITY sqlite-short-version "3.50.4">
+<!ENTITY sqlite-version "3510000">
+<!ENTITY sqlite-short-version "3.51.0">
 <!ENTITY sqlite-year "2025">
-<!ENTITY sqlite-size "3,099 KB">
+<!ENTITY sqlite-size "3,133 KB">
 <!ENTITY sqlite-url "https://sqlite.org/&sqlite-year;/sqlite-autoconf-&sqlite-version;.tar.gz">
-<!ENTITY sqlite-md5 "d74bbdca4ab1b2bd46d3b3f8dbb0f3db">
+<!ENTITY sqlite-md5 "cfcf0004cb6893d2555b33d89ff39cb6">
 <!ENTITY sqlite-home "https://sqlite.org">
 <!ENTITY sqlite-fin-du "71 MB">
 <!ENTITY sqlite-fin-sbu "0.4 SBU">
 <!ENTITY sqlite-doc-version "&sqlite-version;">
-<!ENTITY sqlite-doc-size "5,943 KB">
+<!ENTITY sqlite-doc-size "5,942 KB">
 <!ENTITY sqlite-doc-url  "&anduin-sources;/sqlite-doc-&sqlite-doc-version;.tar.xz">
-<!ENTITY sqlite-doc-md5  "63a62af5b35913459954e6e66876f2b8">
+<!ENTITY sqlite-doc-md5  "383d8db5502bbc385c0415fe3f653cf4">
 
 <!ENTITY sysklogd-version "2.7.2">
 <!ENTITY sysklogd-size "474 KB">

--- a/patches.ent
+++ b/patches.ent
@@ -15,8 +15,8 @@
 <!ENTITY bzip2-docs-patch-md5 "6a5ac7e89b791aae556de0f745916f7f">
 <!ENTITY bzip2-docs-patch-size "1.6 KB">
 
-<!ENTITY coreutils-i18n-patch "coreutils-&coreutils-version;-i18n-2.patch">
-<!ENTITY coreutils-i18n-patch-md5 "c800540039fb0707954197486b1bde70">
+<!ENTITY coreutils-i18n-patch "coreutils-&coreutils-version;-i18n-1.patch">
+<!ENTITY coreutils-i18n-patch-md5 "8456c93be5f3cb406431dd8a29f6527b">
 <!ENTITY coreutils-i18n-patch-size "128 KB">
 
 <!ENTITY expect-gcc15-patch "expect-&expect-version;-gcc15-1.patch">
@@ -26,6 +26,10 @@
 <!ENTITY glibc-fhs-patch "glibc-&glibc-version;-fhs-1.patch">
 <!ENTITY glibc-fhs-patch-md5 "9a5997c3452909b1769918c759eff8a2">
 <!ENTITY glibc-fhs-patch-size "2.8 KB">
+
+<!ENTITY glibc-upstream-patch "glibc-&glibc-version;-upstream_fixes-1.patch">
+<!ENTITY glibc-upstream-patch-md5 "fb47fb9c2732d3c8029bf6be48cd9ea4">
+<!ENTITY glibc-upstream-patch-size "4.3 KB">
 
 <!ENTITY kbd-backspace-patch "kbd-&kbd-version;-backspace-1.patch">
 <!ENTITY kbd-backspace-patch-md5 "f75cca16a38da6caa7d52151f7136895">


### PR DESCRIPTION
Oppdatering til coreutils-9.9.

Oppdatering til binutils-2.45.1. Dette krever nå at du legger til glibc-2.42-upstream_fixes-1.patch.

Oppdatering til libxcrypt-4.5.1.
Oppdatering til linux-6.17.8.
Oppdatering til sqlite-autoconf-3510000 (3.51.0).