### PR TITLE
Tilbakestill "Endre stripping til å bruke --strip-debug"

### DIFF
--- a/chapter08/stripping.xml
+++ b/chapter08/stripping.xml
@@ -24,17 +24,10 @@
   sikkerhetskopiering av LFS systemet i gjeldende tilstand.</para>
 
   <para>En <command>strip</command> kommando med
-  <parameter>--strip-unneeded</parameter> alternativet fjerner alle feilsøkingssymboler fra
-  en binær eller et bibliotek. Den fjerner også alle symboltabelloppføringer som ikke er normalt
+  <parameter>--strip-unneeded</parameter> alternativet fjerner alle feilsøkingssymboler
+  fra en binærfil eller et bibliotek. Den fjerner også alle symboltabelloppføringer som ikke
   og ikke er nødvendig for linkeren (for statiske biblioteker) eller dynamisk linker (for
-  dynamisk koblede binærfiler og delte biblioteker). Å bruke
-  <parameter>--strip-debug</parameter> fjerner ikke symboltabelloppføringer
-  som kan være nødvendig for noen applikasjoner. Forskjellen mellom
-  <literal>unneeded</literal> og <literal>debug</literal> er veldig liten.
-  For eksempel en ustrippet <filename class='libraryfile'>libc.a</filename>
-  er 22.4 MB. Etter stripping med <parameter>--strip-debug</parameter> er
-  den 5.9 MB. Bruk av <parameter>--strip-unneeded</parameter> reduserer bare 
-  størrelsen ytterligere til 5.8 MB.</para>
+  dynamisk koblede binærfiler og delte biblioteker).</para>
 
   <para>Feilsøkingssymbolene fra utvalgte biblioteker komprimeres med
   <application>Zstd</application> og lagres i separate filer. Denne
@@ -87,7 +80,7 @@ cd /usr/lib
 for LIB in $save_usrlib; do
     objcopy --only-keep-debug --compress-debug-sections=zstd $LIB $LIB.dbg
     cp $LIB /tmp/$LIB
-    strip --strip-debug /tmp/$LIB
+    strip --strip-unneeded /tmp/$LIB
     objcopy --add-gnu-debuglink=$LIB.dbg /tmp/$LIB
     install -vm755 /tmp/$LIB /usr/lib
     rm /tmp/$LIB
@@ -106,14 +99,14 @@ online_usrlib="libbfd-&binutils-version;.20260210.so
 
 for BIN in $online_usrbin; do
     cp /usr/bin/$BIN /tmp/$BIN
-    strip --strip-debug /tmp/$BIN
+    strip --strip-unneeded /tmp/$BIN
     install -vm755 /tmp/$BIN /usr/bin
     rm /tmp/$BIN
 done
 
 for LIB in $online_usrlib; do
     cp /usr/lib/$LIB /tmp/$LIB
-    strip --strip-debug /tmp/$LIB
+    strip --strip-unneeded /tmp/$LIB
     install -vm755 /tmp/$LIB /usr/lib
     rm /tmp/$LIB
 done
@@ -124,7 +117,7 @@ for i in $(find /usr/lib -type f -name \*.so* ! -name \*dbg) \
     case "$online_usrbin $online_usrlib $save_usrlib" in
         *$(basename $i)* )
             ;;
-        * ) strip --strip-debug $i
+        * ) strip --strip-unneeded $i
             ;;
     esac
 done


### PR DESCRIPTION
Det ble byttet fra --strip-unneeded til --strip-debug for en stund siden etter at det ble funnet ut at den tidligere "ødelagte" libc.a-filen var ødelagt, noe som førte til at alle rustprogrammer som var koblet mot den krasjet. I august 2025 ble det rapporterte som et binutils problem, men til slutt viste det seg å være en feil i selve libc.a.

Feilen er fikset i glibc 2.43, men var ikke mye tid mellom glibc 2.43 og LFS 13.0, så det ble ikke tilbakestilt for 13.0. Tilbakestill den nå i tidlig fase av 13.1, så er det noen måneder på til å se hva som vil skje.