### PR TITLE
coreutils: Fjern chcon og runcon fra innholdet.

### DIFF
--- a/chapter08/coreutils.xml
+++ b/chapter08/coreutils.xml
@@ -179,13 +179,13 @@ sed -i 's/"1"/"8"/' /usr/share/man/man8/chroot.8</userinput></screen>
       <segtitle>Installert mappe</segtitle>
 
       <seglistitem>
-        <seg>[, b2sum, base32, base64, basename, basenc, cat, chcon, chgrp, chmod, chown,
+        <seg>[, b2sum, base32, base64, basename, basenc, cat, chgrp, chmod, chown,
         chroot, cksum, comm, cp, csplit, cut, date, dd, df, dir, dircolors,
         dirname, du, echo, env, expand, expr, factor, false, fmt, fold, groups,
         head, hostid, id, install, join, link, ln, logname, ls, md5sum, mkdir,
         mkfifo, mknod, mktemp, mv, nice, nl, nohup, nproc, numfmt, od, paste,
         pathchk, pinky, pr, printenv, printf, ptx, pwd, readlink, realpath, rm,
-        rmdir, runcon, seq, sha1sum, sha224sum, sha256sum, sha384sum,
+        rmdir, seq, sha1sum, sha224sum, sha256sum, sha384sum,
         sha512sum, shred, shuf, sleep, sort, split, stat, stdbuf, stty, sum,
         sync, tac, tail, tee, test, timeout, touch, tr, true, truncate, tsort,
         tty, uname, unexpand, uniq, unlink, users, vdir, wc, who, whoami, og
@@ -273,6 +273,7 @@ sed -i 's/"1"/"8"/' /usr/share/man/man8/chroot.8</userinput></screen>
         </listitem>
       </varlistentry>
 
+<!--
       <varlistentry id="chcon">
         <term><command>chcon</command></term>
         <listitem>
@@ -282,6 +283,7 @@ sed -i 's/"1"/"8"/' /usr/share/man/man8/chroot.8</userinput></screen>
           </indexterm>
         </listitem>
       </varlistentry>
+-->
 
       <varlistentry id="chgrp">
         <term><command>chgrp</command></term>
@@ -894,6 +896,7 @@ sed -i 's/"1"/"8"/' /usr/share/man/man8/chroot.8</userinput></screen>
         </listitem>
       </varlistentry>
 
+<!--
       <varlistentry id="runcon">
         <term><command>runcon</command></term>
         <listitem>
@@ -903,6 +906,7 @@ sed -i 's/"1"/"8"/' /usr/share/man/man8/chroot.8</userinput></screen>
           </indexterm>
         </listitem>
       </varlistentry>
+-->
 
       <varlistentry id="seq">
         <term><command>seq</command></term>


### PR DESCRIPTION
chcon og runcon installeres bare hvis selinux er aktivert i Coreutils. Siden vi ikke tilbyr selinux, kan vi trygt fjerne disse to programmene fra listen.