### PR TITLE
cross diffutils: fiks strcasecmp sjekken

### DIFF
--- a/chapter06/diffutils.xml
+++ b/chapter06/diffutils.xml
@@ -47,7 +47,7 @@
 
     <screen><userinput remap="configure">./configure --prefix=/usr   \
             --host=$LFS_TGT \
-            gl_cv_func_strcasecmp_works=y \
+            gl_cv_func_strcasecmp_works=yes \
             --build=$(./build-aux/config.guess)</userinput></screen>
 
     <variablelist>
@@ -58,18 +58,18 @@
         <term><parameter>gl_cv_func_strcasecmp_works=y</parameter></term>
         <listitem>
           <para>Dette alternativet spesifiserer resultatet av en sjekk for
-          <function>strcasecmp</function>.  Sjekken krever å kjøre et
-          kompilert C program, og dette er umulig under
+          <function>strcasecmp</function> funksjonen. Sjekken krever kjøring av 
+          et kompilert C program, og dette er umulig under
           krysskompilering fordi generelt et krysskompilert program
           kan ikke kjøres på vertsdistroen. Normalt for en slik sjekk,
-          <command>configure</command> skriptet vil bruke en reserveverdi
+          vil <command>configure</command> skriptet bruke en reserveverdi
           for krysskompilering, men reserveverdien for denne sjekken er
           fraværende og <command>configure</command> skriptet vil ikke ha noen
           verdi å bruke og vil feile.  Oppstrøms har allerede fikset
           problemet, men for å bruke løsningen må vi kjøre
           <command>autoconf</command> som vertsdistroen kan mangle. Så
-          vi spesifiserer bare sjekkresultatet (<literal>y</literal> siden vi vet
-          at <function>strcasecmp</function> funksjonen i
+          vi spesifiserer bare sjekkresultatet (<literal>yes</literal> siden vi 
+          vet at <function>strcasecmp</function> funksjonen i
           Glibc-&glibc-version; fungerer fint) i stedet,
           <command>configure</command> vil bruke den angitte verdien og
           hoppe over sjekken.</para>


### PR DESCRIPTION
Hvis du setter gl_cv_func_strcasecmp_works til "y (eller noe som ikke slutter på "yes"), kan configure fullføres, men med innstillinger som forhindrer bruk av system strcasecmp funksjonen. Den riktige innstillingen av variabelen er "yes" (eller noe som slutter på "yes"), som lar configure fullføres og systemstrcasecmp funksjonen brukes.

Takk til Manuel Jacob for rapporten.