### PR TITLE
Nevn feil med rullende distribusjoner.

### DIFF
--- a/chapter01/how.xml
+++ b/chapter01/how.xml
@@ -26,6 +26,11 @@
   <para>Som et alternativ til å installere en separat distribusjon på din
   maskin, kan det være lurt å bruke en LiveCD fra en kommersiell distribusjon.</para>
 
+  <note><para>Distribusjonsverter for rullerende utgivelser, som Arch Linux, 
+  oppdaterer ofte til nyere pakkeversjoner ganske raskt, noe som kan forårsake 
+  konfigurasjons eller byggefeil med versjonene av pakkene i denne boken. En ny 
+  kjerne, GCC  eller OpenSSL hovedversjon kan forårsake slike problemer.</para></note>
+
   <!--
   <note>
     <para>LFS LiveCD fungerer kanskje ikke på nyere maskinvarekonfigurasjoner,

--- a/chapter02/hostreqs.xml
+++ b/chapter02/hostreqs.xml
@@ -37,6 +37,9 @@
    <para>Tidligere versjoner av de oppførte programvarepakkene kan fungere, men 
    har ikke blitt testet.</para>
 
+   <para>Vertssystemer som har det nyeste programvaresettet kan forårsake 
+   problemer når man bygger en kryssverktøykjede.</para>
+
   <itemizedlist spacing="compact">
 
     <listitem>


### PR DESCRIPTION
To ganger i løpet av det siste året har Arch Linux oppdatert nye programvareversjoner ganske raskt, noe som gjør at LFS er umulig uten modifikasjoner. Det første tilfellet var en oppdatering til GCC-15.1, og den katastrofen kan gjentas med GCC-16.1. Det andre, nyeste, forekomsten er at de oppdaterte til Linux-7. Dette endret oppførselen til rseq, tabeller og ABI-funksjonen fra 32 til 33, noe som ødelegger Glibc, noe som betyr at brukere må bruke en vert som har Linux <= 6.19.x foreløpig.

Denne destruktive naturen må forklares for brukerne for å hindre dem fra å bruke ødelagte verter.

Gentoo GUI LiveCD (og Gentoo generelt) er et godt eksempel på hvordan man skal behandle programvaren, og ikke oppdatere for tidlig.