### PR TITLE
Pakkeoppdateringer.

### DIFF
--- a/chapter01/changelog.xml
+++ b/chapter01/changelog.xml
@@ -41,6 +41,44 @@
     -->
 
     <listitem>
+      <para>15.06.2026</para>
+      <itemizedlist>
+        <listitem>
+          <para>[bdubbs] - Oppdatering til binutils-2.46.1. Fikser
+          <ulink url="&lfs-ticket-root;5950">#5950</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdatering til file-5.48. Fikser
+          <ulink url="&lfs-ticket-root;5949">#5949</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdatering til less-704. Fikser
+          <ulink url="&lfs-ticket-root;5948">#5948</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdatering til linux-7.0.12. Fikser
+          <ulink url="&lfs-ticket-root;5945">#5945</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdatering til openssl-4.0.1. Fikser
+          <ulink url="&lfs-ticket-root;5951">#5951</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdatering til Python3-3.14.6. Fikser
+          <ulink url="&lfs-ticket-root;5952">#5952</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdatering til sqlite-autoconf-3.53.2. Fikser
+          <ulink url="&lfs-ticket-root;5946">#5946</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdatering til vim-9.2.0640 (Sikkerhetsoppdatering). Fikser
+          <ulink url="&lfs-ticket-root;5947">#5947</ulink>.</para>
+        </listitem>
+      </itemizedlist>
+    </listitem>
+
+    <listitem>
       <para>01.06.2026</para>
       <itemizedlist>
         <listitem>

--- a/chapter01/whatsnew.xml
+++ b/chapter01/whatsnew.xml
@@ -44,9 +44,9 @@
     <!--<listitem>
       <para>Bc-&bc-version;</para>
     </listitem>-->
-    <!--<listitem>
+    <listitem>
       <para>Binutils-&binutils-version;</para>
-    </listitem>-->
+    </listitem>
     <!--<listitem>
       <para>Bison-&bison-version;</para>
     </listitem>-->
@@ -302,8 +302,7 @@
     <title>Lagt til:</title>
     <!--    <listitem><para></para></listitem> -->  <!-- satisfy build -->
     <listitem><para>glibc-2.43-linux7_fixes-1.patch</para></listitem>
-    <listitem><para>Python-3.14.5-openssl_4-1.patch</para></listitem>
-    <listitem><para>Python-3.14.5-security_fixes-1.patch</para></listitem>
+    <listitem><para>Python-3.14.6-openssl_4-1.patch</para></listitem>
     <listitem><para>systemd-260.1-buildfix-1.patch</para></listitem>
   </itemizedlist>
 

--- a/chapter03/patches.xml
+++ b/chapter03/patches.xml
@@ -133,14 +133,6 @@
       </listitem>
     </varlistentry>
 
-    <varlistentry>
-      <term>Python sikkerhet fiks oppdatering - <token>&python-security-fixes-patch-size;</token>:</term>
-      <listitem>
-        <para>Nedlasting: <ulink url="&patches-root;&python-security-fixes-patch;"/></para>
-        <para>MD5 sum: <literal>&python-security-fixes-patch-md5;</literal></para>
-      </listitem>
-    </varlistentry>
-
     <varlistentry revision="sysv">
       <term>SysVinit konsolidert oppdatering - <token>&sysvinit-consolidated-patch-size;</token>:</term>
       <listitem>

--- a/chapter08/python.xml
+++ b/chapter08/python.xml
@@ -47,11 +47,6 @@
 
 <screen><userinput remap="pre">patch -Np1 -i ../&python-openssl4-fixes-patch;</userinput></screen>
 
-    <para>Deretter, fiks to sikkerhetsproblemer:</para>
-
-
-<screen><userinput remap="pre">patch -Np1 -i ../&python-security-fixes-patch;</userinput></screen>
-
     <para>Forbered Python for kompilering:</para>
 
 <screen><userinput remap="configure">./configure --prefix=/usr          \

--- a/packages.ent
+++ b/packages.ent
@@ -65,10 +65,10 @@
 <!ENTITY bc-fin-du "7.8 MB">
 <!ENTITY bc-fin-sbu "mindre enn 0.1 SBU">
 
-<!ENTITY binutils-version "2.46.0">
-<!ENTITY binutils-size "27,880 KB">
+<!ENTITY binutils-version "2.46.1">
+<!ENTITY binutils-size "27,966 KB">
 <!ENTITY binutils-url "https://sourceware.org/pub/binutils/releases/binutils-&binutils-version;.tar.xz">
-<!ENTITY binutils-md5 "81bb6810bcd1119819dc0804956e1c92">
+<!ENTITY binutils-md5 "9b9b73791519bf6fc8d76c7fc9fd32fe">
 <!ENTITY binutils-home "&gnu-software;binutils/">
 <!ENTITY binutils-tmpp1-du "691 MB">
 <!ENTITY binutils-tmpp1-sbu "1 SBU">
@@ -165,10 +165,10 @@
 <!ENTITY expect-tmp-du "3.9 MB">
 <!ENTITY expect-tmp-sbu "0.2 SBU">
 
-<!ENTITY file-version "5.47">
-<!ENTITY file-size "2,615 KB">
+<!ENTITY file-version "5.48">
+<!ENTITY file-size "2,631 KB">
 <!ENTITY file-url "https://astron.com/pub/file/file-&file-version;.tar.gz">
-<!ENTITY file-md5 "1023ef52a2fb64acdf80211e469d6939">
+<!ENTITY file-md5 "423686e97f731d8c24e9cd1a22b03dec">
 <!ENTITY file-home "https://www.darwinsys.com/file/">
 <!ENTITY file-tmp-du "43 MB">
 <!ENTITY file-tmp-sbu "0.1 SBU">
@@ -366,10 +366,10 @@
 <!ENTITY kmod-fin-du "6.7 MB">
 <!ENTITY kmod-fin-sbu "mindre enn 0.1 SBU">
 
-<!ENTITY less-version "702">
+<!ENTITY less-version "704">
 <!ENTITY less-size "974 KB">
 <!ENTITY less-url "https://www.greenwoodsoftware.com/less/less-&less-version;.tar.gz">
-<!ENTITY less-md5 "6357604422b12b71c534d0e34f41d4c5">
+<!ENTITY less-md5 "c4c9eea5b1862783b078c67ca67c9185">
 <!ENTITY less-home "https://www.greenwoodsoftware.com/less/">
 <!ENTITY less-fin-du "17 MB">
 <!ENTITY less-fin-sbu "0.1 SBU">
@@ -425,12 +425,12 @@
 <!ENTITY linux-major-version "7">
 <!ENTITY linux-minor-version "0">
 <!ENTITY linux-majmin-version "&linux-major-version;.&linux-minor-version;">
-<!ENTITY linux-patch-version "10">
+<!ENTITY linux-patch-version "12">
 <!--<!ENTITY linux-version "&linux-major-version;.&linux-minor-version;">-->
 <!ENTITY linux-version "&linux-major-version;.&linux-minor-version;.&linux-patch-version;">
-<!ENTITY linux-size "153,576 KB">
+<!ENTITY linux-size "153,556 KB">
 <!ENTITY linux-url "&kernel;linux/kernel/v&linux-major-version;.x/linux-&linux-version;.tar.xz">
-<!ENTITY linux-md5 "99f85199a3d605feabb4b525fbebc7f4">
+<!ENTITY linux-md5 "0e510b924210c2f4a8429dce4ee7bb4c">
 <!ENTITY linux-home "https://www.kernel.org/">
 <!-- measured for 6.10.1 / gcc-14.1.0 on x86_64 with -j4 : 
  minimum is allnoconfig 
@@ -540,10 +540,10 @@
 <!ENTITY ninja-fin-du "43 MB">
 <!ENTITY ninja-fin-sbu "0.2 SBU">
 
-<!ENTITY openssl-version "4.0.0">
-<!ENTITY openssl-size "53,757 KB">
+<!ENTITY openssl-version "4.0.1">
+<!ENTITY openssl-size "53,789 KB">
 <!ENTITY openssl-url "&github;/openssl/openssl/releases/download/openssl-&openssl-version;/openssl-&openssl-version;.tar.gz">
-<!ENTITY openssl-md5 "f26714e6398a2d921fc5616daaa75231">
+<!ENTITY openssl-md5 "07e316afe26b61e72206b81706b497bb">
 <!ENTITY openssl-home "https://www.openssl-library.org/">
 <!ENTITY openssl-fin-du "981 MB">
 <!ENTITY openssl-fin-sbu "1.9 SBU">
@@ -615,19 +615,19 @@
 <!-- If python minor version changes, updates in python and
      meson pages will be needed: python3.6 and python3.6m -->
 
-<!ENTITY python-version "3.14.5">
+<!ENTITY python-version "3.14.6">
 <!ENTITY python-minor "3.14">
-<!ENTITY python-size "23,344 KB">
+<!ENTITY python-size "23,361 KB">
 <!ENTITY python-url "https://www.python.org/ftp/python/&python-version;/Python-&python-version;.tar.xz">
-<!ENTITY python-md5 "16beaf44e56ed4b8254f625504b08a7f">
+<!ENTITY python-md5 "d28d7fb81a61d3bff5a6bedceb969366">
 <!ENTITY python-home "https://www.python.org/">
 <!ENTITY python-tmp-du "592 MB">
 <!ENTITY python-tmp-sbu "0.5 SBU">
 <!ENTITY python-fin-du "494 MB">
 <!ENTITY python-fin-sbu "2.6 SBU">
 <!ENTITY python-docs-url "https://www.python.org/ftp/python/doc/&python-version;/python-&python-version;-docs-html.tar.bz2">
-<!ENTITY python-docs-md5 "b5e4e78aecd57de93837810d279598e2">
-<!ENTITY python-docs-size "10,718 KB">
+<!ENTITY python-docs-md5 "95c7483f256f6f0596c9e644756dc556">
+<!ENTITY python-docs-size "10,746 KB">
 
 <!ENTITY readline-version "8.3">
 <!ENTITY readline-soversion "8.3"><!-- used for stripping -->
@@ -664,19 +664,19 @@
 <!ENTITY shadow-fin-du "115 MB">
 <!ENTITY shadow-fin-sbu "0.1 SBU">
 
-<!ENTITY sqlite-version "3530100">
-<!ENTITY sqlite-short-version "3.53.1">
+<!ENTITY sqlite-version "3530200">
+<!ENTITY sqlite-short-version "3.53.2">
 <!ENTITY sqlite-year "2026">
-<!ENTITY sqlite-size "3,199 KB">
+<!ENTITY sqlite-size "3,204 KB">
 <!ENTITY sqlite-url "https://sqlite.org/&sqlite-year;/sqlite-autoconf-&sqlite-version;.tar.gz">
-<!ENTITY sqlite-md5 "af0fd4332e87e0d028aece375dbd2c84">
+<!ENTITY sqlite-md5 "a86a69e9c35dcf886e2ab4ccc6062ac2">
 <!ENTITY sqlite-home "https://sqlite.org">
 <!ENTITY sqlite-fin-du "124 MB">
 <!ENTITY sqlite-fin-sbu "0.4 SBU">
 <!ENTITY sqlite-doc-version "&sqlite-version;">
-<!ENTITY sqlite-doc-size "6,096 KB">
+<!ENTITY sqlite-doc-size "6,175 KB">
 <!ENTITY sqlite-doc-url  "&anduin-sources;/sqlite-doc-&sqlite-doc-version;.tar.xz">
-<!ENTITY sqlite-doc-md5  "61163af56e5d88a181a40be0be850495">
+<!ENTITY sqlite-doc-md5  "44a7cb532169ed7cf3b6e5ffe19c7806">
 
 <!ENTITY sysklogd-version "2.7.2">
 <!ENTITY sysklogd-size "474 KB">
@@ -769,9 +769,9 @@
 <!ENTITY util-linux-fin-du "346 MB">
 <!ENTITY util-linux-fin-sbu "0.5 SBU">
 
-<!ENTITY vim-version "9.2.0567">
+<!ENTITY vim-version "9.2.0640">
 <!ENTITY vim-docdir "vim/vim92">
-<!ENTITY vim-size "19,586 KB">
+<!ENTITY vim-size "19,683 KB">
 <!ENTITY vim-url "https://github.com/vim/vim/archive/v&vim-version;/vim-&vim-version;.tar.gz">
 <!-- N.B. LFS 9.0 uses
      https://github.com/vim/vim/archive/v8.1.1846/vim-8.1.1846.tar.gz
@@ -784,7 +784,7 @@
      release.  The "Next" button just sets "after=" in the URL.  For
      example, https://github.com/vim/vim/tags?after=v8.1.1847 will show
      us v8.1.1846. -->
-<!ENTITY vim-md5 "21f8aec8ca0422156ac7de1a92a49901">
+<!ENTITY vim-md5 "6a5ddc247f0e17b66a0172f06924b719">
 <!ENTITY vim-home "https://www.vim.org">
 <!ENTITY vim-fin-du "217 MB">
 <!ENTITY vim-fin-sbu "3.2 SBU">

--- a/patches.ent
+++ b/patches.ent
@@ -45,10 +45,6 @@
 <!ENTITY python-openssl4-fixes-patch-md5 "597d7737df1b4ea4e184c193da523050">
 <!ENTITY python-openssl4-fixes-patch-size "38 KB">
 
-<!ENTITY python-security-fixes-patch "Python-&python-version;-security_fixes-1.patch">
-<!ENTITY python-security-fixes-patch-md5 "1d5084c858197e82f0611b82f0d852f5">
-<!ENTITY python-security-fixes-patch-size "12 KB">
-
 <!--
 <!ENTITY readline-fixes-patch "readline-&readline-version;-upstream_fixes-3.patch">
 <!ENTITY readline-fixes-patch-md5 "9ed497b6cb8adcb8dbda9dee9ebce791">


### PR DESCRIPTION
Oppdatering til binutils-2.46.1.
Oppdatering til file-5.48.
Oppdatering til less-704.
Oppdatering til linux-7.0.12.
Oppdatering til openssl-4.0.1.
Oppdatering til Python3-3.14.6.
Oppdatering til sqlite-autoconf-3.53.2.
Oppdatering til vim-9.2.0640 (Sikkerhetsoppdatering).