### PR TITLE
ch05/libstdc++: sett CXX=$LFS_TGT-gcc

### DIFF
--- a/chapter05/libstdc++.xml
+++ b/chapter05/libstdc++.xml
@@ -63,6 +63,7 @@ cd       build</userinput></screen>
 <screen><userinput remap="configure">../libstdc++-v3/configure      \
     --host=$LFS_TGT            \
     --build=$(../config.guess) \
+    CXX=$LFS_TGT-gcc           \
     --prefix=/usr              \
     --disable-multilib         \
     --disable-nls              \
@@ -78,6 +79,23 @@ cd       build</userinput></screen>
           <para>Spesifiserer at krysskompilatoren vi nettopp har bygget
           skal brukes i stedet for den i
           <filename>/usr/bin</filename>.</para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term><parameter>CXX=$LFS_TGT-gcc</parameter></term>
+        <listitem>
+          <para>Spesifiserer å bruke <command>$LFS_TGT-gcc</command> å kompilere 
+          C++ koden. Standardinnstillingen, <command>$LFS_TGT-g++</command>,
+          ville automatisk spesifisere kobling mot
+          <systemitem class='library'>libstdc++</systemitem> når man aktiverer 
+          lenkeren, men i vårt tilfelle
+          <systemitem class='library'>libstdc++</systemitem> er ikke installert 
+          ennå, så noen kontroller i <command>configure</command>
+          skriptet ville oppføre seg feil med <command>$LFS_TGT-g++</command>.  
+          I en vanlig bygging sendes denne overstyringen automatisk til
+          <command>configure</command> skript fra toppnivåmappen. 
+          Her sender vi det eksplisitt.</para>
         </listitem>
       </varlistentry>
 


### PR DESCRIPTION
I en vanlig GCC bygging setter Makefile på toppnivå automatisk CXX=xgcc. Og uten den vil "sjekking for sin i -lm"-proben mislykkes, og da vil GCC tro at mattefunksjonene (for eksempel acosf) ikke er tilgjengelige og mislykkes i å bygge std.gcm (lagt til siden GCC 16) med omtrent et dusin linjer med feilmeldinger, noe som sannsynligvis ville forvirret brukeren hvis den oppdages.