### PR TITLE
Pakkeoppdateringer.

### DIFF
--- a/chapter01/changelog.xml
+++ b/chapter01/changelog.xml
@@ -41,6 +41,37 @@
     -->
 
     <listitem>
+      <para>07.08.2026</para>
+      <itemizedlist>
+        <listitem>
+          <para>[bdubbs] - Oppdatering til flit_core-4.0.2 (Python modul). Fikser
+          <ulink url="&lfs-ticket-root;5989">#5989</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdatering til gcc-16.2.0. Fikser
+          <ulink url="&lfs-ticket-root;5992">#5992</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdatering til linux-7.1.7. Fikser
+          <ulink url="&lfs-ticket-root;5988">#5988</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdatering til packaging-26.3 (Python module. Fikser
+          <ulink url="&lfs-ticket-root;5990">#5990</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdatering til pkgconf-3.0.5. Fikser
+          <ulink url="&lfs-ticket-root;5987">#5987</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Oppdatering til Python-3.14.7 (Sikkerhetsoppdatering). Fikser
+          <ulink url="&lfs-ticket-root;5991">#5991</ulink>.</para>
+        </listitem>
+      </itemizedlist>
+    </listitem>
+
+
+    <listitem>
       <para>01.08.2026</para>
       <itemizedlist>
         <listitem>

--- a/chapter01/whatsnew.xml
+++ b/chapter01/whatsnew.xml
@@ -83,15 +83,15 @@
     <!--<listitem>
       <para>Flex-&flex-version;</para>
     </listitem>-->
-    <!--<listitem>
+    <listitem>
       <para>Flit-Core-&flit-core-version;</para>
-    </listitem>-->
+    </listitem>
     <listitem>
       <para>Gawk-&gawk-version;</para>
     </listitem>
-    <!--<listitem>
+    <listitem>
        <para>GCC-&gcc-version;</para>
-    </listitem>-->
+    </listitem>
     <!--<listitem>
        <para>GDBM-&gdbm-version;</para>
     </listitem>-->

--- a/chapter03/patches.xml
+++ b/chapter03/patches.xml
@@ -126,10 +126,10 @@
     </varlistentry>
 -->
     <varlistentry>
-      <term>Python konsolidert oppdatering - <token>&python-consolidated-fixes-patch-size;</token>:</term>
+      <term>Python Openssl4 oppdatering - <token>&python-openssl4-fixes-patch-size;</token>:</term>
       <listitem>
-        <para>Nedlasting: <ulink url="&patches-root;&python-consolidated-fixes-patch;"/></para>
-        <para>MD5 sum: <literal>&python-consolidated-fixes-patch-md5;</literal></para>
+        <para>Nedlasting: <ulink url="&patches-root;&python-openssl4-fixes-patch;"/></para>
+        <para>MD5 sum: <literal>&python-openssl4-fixes-patch-md5;</literal></para>
       </listitem>
     </varlistentry>
 
@@ -152,7 +152,7 @@
     <varlistentry>
       <term>Tar oppstrøms oppdatering - <token>&tar-aclfix-patch-size;</token>:</term>
       <listitem>
-        <para>Download: <ulink url="&patches-root;&tar-aclfix-patch;"/></para>
+        <para>Nedlasting: <ulink url="&patches-root;&tar-aclfix-patch;"/></para>
         <para>MD5 sum: <literal>&tar-aclfix-patch-md5;</literal></para>
       </listitem>
     </varlistentry>

--- a/chapter08/python.xml
+++ b/chapter08/python.xml
@@ -45,7 +45,7 @@
 
     <para>Først, installer en oppdatering for kompatibilitet med OpenSSL4:</para>
 
-<screen><userinput remap="pre">patch -Np1 -i ../&python-consolidated-fixes-patch;</userinput></screen>
+<screen><userinput remap="pre">patch -Np1 -i ../&python-openssl4-fixes-patch;</userinput></screen>
 
     <para>Forbered Python for kompilering:</para>
 

--- a/packages.ent
+++ b/packages.ent
@@ -194,10 +194,10 @@
 <!ENTITY flex-fin-du "33 MB">
 <!ENTITY flex-fin-sbu "0.1 SBU">
 
-<!ENTITY flit-core-version "3.12.0">
-<!ENTITY flit-core-size "53 KB">
+<!ENTITY flit-core-version "4.0.2">
+<!ENTITY flit-core-size "52 KB">
 <!ENTITY flit-core-url "&pypi-src;/f/flit-core/flit_core-&flit-core-version;.tar.gz">
-<!ENTITY flit-core-md5 "c538415c1f27bd69cbbbf3cdd5135d39">
+<!ENTITY flit-core-md5 "89ebb783230fc8db6c1d2a39644b7085">
 <!ENTITY flit-core-home "&pypi-home;/flit-core/">
 <!ENTITY flit-core-fin-du "1.3 MB">
 <!ENTITY flit-core-fin-sbu "mindre enn 0.1 SBU">
@@ -212,10 +212,10 @@
 <!ENTITY gawk-fin-du "45 MB">
 <!ENTITY gawk-fin-sbu "0.2 SBU">
 
-<!ENTITY gcc-version "16.1.0">
-<!ENTITY gcc-size "100,056 KB">
+<!ENTITY gcc-version "16.2.0">
+<!ENTITY gcc-size "104,689 KB">
 <!ENTITY gcc-url "&gnu;gcc/gcc-&gcc-version;/gcc-&gcc-version;.tar.xz">
-<!ENTITY gcc-md5 "9b016416f8e2dce4a0ef8759d1936446">
+<!ENTITY gcc-md5 "19b777fb19ea4982731392481306f0d3">
 <!ENTITY gcc-home "https://gcc.gnu.org/">
 <!ENTITY gcc-tmpp1-du "5.4 GB">
 <!ENTITY gcc-tmpp1-sbu "3.8 SBU">
@@ -224,7 +224,7 @@
 <!ENTITY gcc-fin-du "6.6 GB ">
 <!ENTITY gcc-fin-sbu "45 SBU (med tester)">
 <!ENTITY libquadmath-version "0.0.0">
-<!ENTITY libstdcpp-version   "6.0.35">
+<!ENTITY libstdcpp-version   "6.0.36">
 <!ENTITY libitm-version      "1.0.0">
 <!ENTITY libatomic-version   "1.2.0">
 
@@ -426,12 +426,12 @@
 <!ENTITY linux-major-version "7">
 <!ENTITY linux-minor-version "1">
 <!ENTITY linux-majmin-version "&linux-major-version;.&linux-minor-version;">
-<!ENTITY linux-patch-version "5">
+<!ENTITY linux-patch-version "7">
 <!--<!ENTITY linux-version "&linux-major-version;.&linux-minor-version;">-->
 <!ENTITY linux-version "&linux-major-version;.&linux-minor-version;.&linux-patch-version;">
-<!ENTITY linux-size "154,690 KB">
+<!ENTITY linux-size "154,694 KB">
 <!ENTITY linux-url "&kernel;linux/kernel/v&linux-major-version;.x/linux-&linux-version;.tar.xz">
-<!ENTITY linux-md5 "75f719d50ea10e0bb623a95f468600cb">
+<!ENTITY linux-md5 "c28c8e23d4f51f8a444f26b6b9badcfc">
 <!ENTITY linux-home "https://www.kernel.org/">
 <!-- measured for 6.10.1 / gcc-14.1.0 on x86_64 with -j4 : 
  minimum is allnoconfig 
@@ -559,10 +559,10 @@
 <!ENTITY openssl-fin-du "981 MB">
 <!ENTITY openssl-fin-sbu "1.9 SBU">
 
-<!ENTITY packaging-version "26.2">
-<!ENTITY packaging-size "223 KB">
+<!ENTITY packaging-version "26.3">
+<!ENTITY packaging-size "307 KB">
 <!ENTITY packaging-url "https://files.pythonhosted.org/packages/source/p/packaging/packaging-&packaging-version;.tar.gz">
-<!ENTITY packaging-md5 "edae3d061c39a2ff713a97e133dbc50c">
+<!ENTITY packaging-md5 "c6809ec56986682ceffe573b8778a1ce">
 <!ENTITY packaging-home "&pypi-home;/packaging/">
 <!ENTITY packaging-fin-du "1.6 MB">
 <!ENTITY packaging-fin-sbu "mindre enn 0.1 SBU">
@@ -599,10 +599,10 @@
 <!ENTITY perl-fin-du "257 MB">
 <!ENTITY perl-fin-sbu "1.3 SBU">
 
-<!ENTITY pkgconf-version "3.0.4">
-<!ENTITY pkgconf-size "409 KB">
+<!ENTITY pkgconf-version "3.0.5">
+<!ENTITY pkgconf-size "417 KB">
 <!ENTITY pkgconf-url "https://distfiles.ariadne.space/pkgconf/pkgconf-&pkgconf-version;.tar.xz">
-<!ENTITY pkgconf-md5 "278da81c44a99aa21facf5b7f43c9adc">
+<!ENTITY pkgconf-md5 "18c528161e6b04ae36dc981af8c4d97e">
 <!ENTITY pkgconf-home "https://github.com/pkgconf/pkgconf">
 <!ENTITY pkgconf-fin-du "5.0 MB">
 <!ENTITY pkgconf-fin-sbu "mindre enn 0.1 SBU">
@@ -626,19 +626,19 @@
 <!-- If python minor version changes, updates in python and
      meson pages will be needed: python3.6 and python3.6m -->
 
-<!ENTITY python-version "3.14.6">
+<!ENTITY python-version "3.14.7">
 <!ENTITY python-minor "3.14">
-<!ENTITY python-size "23,361 KB">
+<!ENTITY python-size "23,911 KB">
 <!ENTITY python-url "https://www.python.org/ftp/python/&python-version;/Python-&python-version;.tar.xz">
-<!ENTITY python-md5 "d28d7fb81a61d3bff5a6bedceb969366">
+<!ENTITY python-md5 "a4c4c2991b4126e227073c2d9445f432">
 <!ENTITY python-home "https://www.python.org/">
 <!ENTITY python-tmp-du "592 MB">
 <!ENTITY python-tmp-sbu "0.5 SBU">
 <!ENTITY python-fin-du "494 MB">
 <!ENTITY python-fin-sbu "2.6 SBU">
 <!ENTITY python-docs-url "https://www.python.org/ftp/python/doc/&python-version;/python-&python-version;-docs-html.tar.bz2">
-<!ENTITY python-docs-md5 "95c7483f256f6f0596c9e644756dc556">
-<!ENTITY python-docs-size "10,746 KB">
+<!ENTITY python-docs-md5 "bdf55dddc02a76961d61730f06d18849">
+<!ENTITY python-docs-size "10,916 KB">
 
 <!ENTITY readline-version "8.3">
 <!ENTITY readline-soversion "8.3"><!-- used for stripping -->

--- a/patches.ent
+++ b/patches.ent
@@ -31,7 +31,6 @@
 <!ENTITY glibc-upstream-patch-md5 "5d589fb5bf76f3efaa19dcd12d4484a4">
 <!ENTITY glibc-upstream-patch-size "3.3 KB">
 
-
 <!ENTITY kbd-backspace-patch "kbd-&kbd-version;-backspace-1.patch">
 <!ENTITY kbd-backspace-patch-md5 "f75cca16a38da6caa7d52151f7136895">
 <!ENTITY kbd-backspace-patch-size "12 KB">
@@ -42,9 +41,9 @@
 <!ENTITY perl-upstream-fix-patch-size "13 KB">
 -->
 
-<!ENTITY python-consolidated-fixes-patch "Python-&python-version;-consolidated_fixes-1.patch">
-<!ENTITY python-consolidated-fixes-patch-md5 "263746d5e08aa2c9f2d9d7060435dec4">
-<!ENTITY python-consolidated-fixes-patch-size "37 KB">
+<!ENTITY python-openssl4-fixes-patch "Python-&python-version;-openssl_4-1.patch">
+<!ENTITY python-openssl4-fixes-patch-md5 "597d7737df1b4ea4e184c193da523050">
+<!ENTITY python-openssl4-fixes-patch-size "38 KB">
 
 <!--
 <!ENTITY readline-fixes-patch "readline-&readline-version;-upstream_fixes-3.patch">
@@ -65,3 +64,4 @@
 <!ENTITY tar-aclfix-patch "tar-&tar-version;-acl_fix-1.patch">
 <!ENTITY tar-aclfix-patch-md5 "dbab49e317105539611866dac5dd54f6">
 <!ENTITY tar-aclfix-patch-size "4.3 KB">
+


### PR DESCRIPTION
Oppdatering til flit_core-4.0.2 (Python modul).
Oppdatering til gcc-16.2.0.
Oppdatering til linux-7.1.7.
Oppdatering til packaging-26.3 (Python modul).
Oppdatering til pkgconf-3.0.5.
Oppdatering til Python-3.14.7 (sikkerhetsoppdatering).